### PR TITLE
Switch to docker multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine
+FROM golang:1.13-alpine as builder
 
 WORKDIR /app
 
@@ -10,6 +10,11 @@ COPY . .
 
 RUN go build -o emulator .
 
-EXPOSE 8123
 
-ENTRYPOINT ["./emulator"]
+FROM alpine:latest
+
+ENTRYPOINT ["/emulator"]
+
+WORKDIR /
+
+COPY --from=builder /app/emulator .


### PR DESCRIPTION
This reduces the size of the result image since the run time version does not need the compilers.