### PR TITLE
Validate task names on creation

### DIFF
--- a/emulator.go
+++ b/emulator.go
@@ -236,7 +236,6 @@ func (s *Server) GetTask(ctx context.Context, in *tasks.GetTaskRequest) (*tasks.
 
 // CreateTask creates a new task
 func (s *Server) CreateTask(ctx context.Context, in *tasks.CreateTaskRequest) (*tasks.Task, error) {
-	// TODO: task name validation
 
 	queueName := in.GetParent()
 	queue, ok := s.fetchQueue(queueName)
@@ -245,6 +244,10 @@ func (s *Server) CreateTask(ctx context.Context, in *tasks.CreateTaskRequest) (*
 	}
 	if queue == nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "The queue no longer exists, though a queue with this name existed recently.")
+	}
+
+	if (in.Task.Name != "") && !isValidTaskName(in.Task.Name) {
+		return nil, status.Errorf(codes.InvalidArgument, `Task name must be formatted: "projects/<PROJECT_ID>/locations/<LOCATION_ID>/queues/<QUEUE_ID>/tasks/<TASK_ID>"`)
 	}
 
 	task, taskState := queue.NewTask(in.GetTask())

--- a/task.go
+++ b/task.go
@@ -37,6 +37,10 @@ func parseTaskName(task *tasks.Task) TaskNameParts {
 	}
 }
 
+func isValidTaskName(name string) bool {
+	return r.MatchString(name)
+}
+
 type TaskNameParts struct {
 	project  string
 	location string


### PR DESCRIPTION
Somewhat confusingly, the task `name` always has to be fully
qualified with the queue path on creation (even though this is
already provided in the separate `parent` field). It is not
sufficient to just pass the `task id`.

The emulator was ignoring this, but since 3cebcfe the dispatch
method needs to parse the task name to set the HTTP headers.
This was causing an emulator panic if the name was invalid.

This commit validates that the task name matches the regex at time
of creation. The returned error matches the actual response that
GCP returns in this situation.