### PR TITLE
Reject tasks with duplicate names

### DIFF
--- a/emulator.go
+++ b/emulator.go
@@ -25,7 +25,14 @@ func NewServer() *Server {
 	return &Server{
 		qs: make(map[string]*Queue),
 		ts: make(map[string]*Task),
+		Options: ServerOptions{
+			HardResetOnPurgeQueue: false,
+		},
 	}
+}
+
+type ServerOptions struct {
+	HardResetOnPurgeQueue bool
 }
 
 // Server represents the emulator server
@@ -33,8 +40,9 @@ type Server struct {
 	qs map[string]*Queue
 	ts map[string]*Task
 
-	qsMux sync.Mutex
-	tsMux sync.Mutex
+	qsMux   sync.Mutex
+	tsMux   sync.Mutex
+	Options ServerOptions
 }
 
 func (s *Server) setQueue(queueName string, queue *Queue) {
@@ -69,6 +77,12 @@ func (s *Server) fetchTask(taskName string) (*Task, bool) {
 
 func (s *Server) removeTask(taskName string) {
 	s.setTask(taskName, nil)
+}
+
+func (s *Server) hardDeleteTask(taskName string) {
+	s.tsMux.Lock()
+	defer s.tsMux.Unlock()
+	delete(s.ts, taskName)
 }
 
 // ListQueues lists the existing queues
@@ -165,7 +179,13 @@ func (s *Server) DeleteQueue(ctx context.Context, in *tasks.DeleteQueueRequest) 
 func (s *Server) PurgeQueue(ctx context.Context, in *tasks.PurgeQueueRequest) (*tasks.Queue, error) {
 	queue, _ := s.fetchQueue(in.GetName())
 
-	queue.Purge()
+	if s.Options.HardResetOnPurgeQueue {
+		// Use the development environment behaviour - synchronously purge the queue and release all task names
+		queue.HardReset(s)
+	} else {
+		// Mirror production behaviour - spin off an asynchronous purge operation and return
+		queue.Purge()
+	}
 
 	return queue.state, nil
 }
@@ -335,6 +355,7 @@ func main() {
 	host := flag.String("host", "localhost", "The host name")
 	port := flag.String("port", "8123", "The port")
 	openidIssuer := flag.String("openid-issuer", "", "URL to serve the OpenID configuration on, if required")
+	hardResetOnPurgeQueue := flag.Bool("hard-reset-on-purge-queue", false, "Set to force the 'Purge Queue' call to perform a hard reset of all state (differs from production)")
 
 	flag.Var(&initialQueues, "queue", "A queue to create on startup (repeat as required)")
 
@@ -357,6 +378,7 @@ func main() {
 
 	grpcServer := grpc.NewServer()
 	emulatorServer := NewServer()
+	emulatorServer.Options.HardResetOnPurgeQueue = *hardResetOnPurgeQueue
 	tasks.RegisterCloudTasksServer(grpcServer, emulatorServer)
 
 	for i := 0; i < len(initialQueues); i++ {

--- a/emulator.go
+++ b/emulator.go
@@ -249,8 +249,14 @@ func (s *Server) CreateTask(ctx context.Context, in *tasks.CreateTaskRequest) (*
 		return nil, status.Errorf(codes.FailedPrecondition, "The queue no longer exists, though a queue with this name existed recently.")
 	}
 
-	if (in.Task.Name != "") && !isValidTaskName(in.Task.Name) {
-		return nil, status.Errorf(codes.InvalidArgument, `Task name must be formatted: "projects/<PROJECT_ID>/locations/<LOCATION_ID>/queues/<QUEUE_ID>/tasks/<TASK_ID>"`)
+	if in.Task.Name != "" {
+		// If a name is specified, it must be valid and it must be unique
+		if !isValidTaskName(in.Task.Name) {
+			return nil, status.Errorf(codes.InvalidArgument, `Task name must be formatted: "projects/<PROJECT_ID>/locations/<LOCATION_ID>/queues/<QUEUE_ID>/tasks/<TASK_ID>"`)
+		}
+		if _, exists := s.fetchTask(in.Task.Name); exists {
+			return nil, status.Errorf(codes.AlreadyExists, "Requested entity already exists")
+		}
 	}
 
 	task, taskState := queue.NewTask(in.GetTask())

--- a/readme.MD
+++ b/readme.MD
@@ -109,6 +109,27 @@ use in docker / k8s environments.
 You can, of course, export the content of the `/jwks` url if you prefer to
 hardcode the public keys in your application.
 
+## Flushing task state
+
+By default, the emulator tracks the names of every task created since the emulator launched. The list
+of task names survives task completion, deletion, and purge queue operations. Completed / removed tasks
+do not appear in ListTasks, but calling GetTask or CreateTask with a name that has been used in the
+past will return an error. This mirrors the behaviour of Cloud Tasks - although note that unlike
+Cloud Tasks the emulator does not attempt to garbage collect the list of task names over time.
+
+For some usecases, you may want to completely reset the list of task names without restarting the
+emulator - e.g. between each scenario in a test run.
+
+The optional `hard-reset-on-purge-queue` flag configures the emulator so that calling `PurgeQueue`
+will remove all record of past tasks. It also switches `PurgeQueue` to be a synchronous operation
+which only returns once all tasks have been cancelled and the queue is empty. Queued tasks may, of
+course, still fire during the PurgeQueue operation - but they cannot fire after PurgeQueue has
+returned.
+
+```
+go run ./ --hard-reset-on-purge-queue
+```
+
 ## Examples
 
 ### Python example


### PR DESCRIPTION
Per the [docs](https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues.tasks/create#body.request_body.FIELDS.task)

> Explicitly specifying a task ID enables task de-duplication. If a task's ID is identical to that of an existing task or a task that was deleted or executed recently then the call will fail with `google.rpc.Code.ALREADY_EXISTS`. If the 
task's queue was created using Cloud Tasks, then another task with the same name can't be created for ~1hour after the original task was deleted or executed. If the task's queue was created using queue.yaml or queue.xml,
then another task with the same name can't be created for ~9days after the original task was deleted or executed.

For the purposes of the emulator, I don't think it's necessary to model the time-based garbage collection of old task names?

NB though that at the moment task names survive until the emulator is restarted - even through a call to `purgeQueue`.

That matches the behaviour of Google Cloud Tasks, but may not be ideal for local testing. For example, when testing code that uses explicit task names, it would probably be useful to reset that state before each test. But that would mean either making PurgeQueue behave differently to prod, or adding a separate API method specifically to be called by test setup / teardown code that does more of a "hard reset". What do you think?

NB also that this has a merge conflict with #20 - I can resolve that if/when either of these is merged.