### PR TITLE
Add possibility of creating on the fly the queue needed by a task.

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -41,6 +41,14 @@ go run ./ -host localhost \
   -queue projects/dev/locations/here/queues/anotherq
 ```
 
+You can also request queue to be created on the fly when a task arrived for an unknown queue:
+
+```
+go run ./ -host localhost \
+  -port 8000 \
+  -auto-create-queue
+```
+
 Once running, you connect to it using the standard google cloud tasks GRPC libraries.
 
 ### Docker


### PR DESCRIPTION
Hi,

I am starting to use your emulator but in ours projects we have a lot of queues (more than 10 sometimes). So it is quite 
annoying if we have to declare all of them, that is why I propose this merge request that add the *-auto-create-queue* optional parameter. If set, when a task on an unkown queue arrived, it creates the queue so the task request won't failed.
