### PR TITLE
Fix unconventional example queue path

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -127,7 +127,7 @@ channel = grpc.insecure_channel('localhost:8123')
 transport = CloudTasksGrpcTransport(channel=channel)
 client = CloudTasksClient(transport=transport)
 
-parent = '/projects/my-sandbox/locations/us-central1'
+parent = 'projects/my-sandbox/locations/us-central1'
 queue_name = parent + '/queues/test'
 client.create_queue(queue={'name': queue_name}, parent=parent)
 


### PR DESCRIPTION
I noticed in the readme that a queue path is used that does not follow GCP's standard. It is subtle, but a leading forward slash is used in the path, which GCP does not use. This confused me for a little while, so I thought it could potentially confuse others.

But thank you for open sourcing this! It is proving helpful for our testing!