### PR TITLE
Improve resilience / stability of tests

### DIFF
--- a/emulator_test.go
+++ b/emulator_test.go
@@ -214,6 +214,7 @@ func TestSuccessTaskExecution(t *testing.T) {
 		},
 	}
 	createdTask, err := client.CreateTask(context.Background(), &createTaskRequest)
+	require.NoError(t, err)
 
 	getTaskRequest := taskspb.GetTaskRequest{
 		Name: createdTask.GetName(),
@@ -276,7 +277,8 @@ func TestSuccessAppEngineTaskExecution(t *testing.T) {
 		},
 	}
 
-	createdTask, _ := client.CreateTask(context.Background(), &createTaskRequest)
+	createdTask, err := client.CreateTask(context.Background(), &createTaskRequest)
+	require.NoError(t, err)
 
 	// Need to give it a chance to make the actual call
 	time.Sleep(100 * time.Millisecond)
@@ -323,6 +325,7 @@ func TestErrorTaskExecution(t *testing.T) {
 		},
 	}
 	createdTask, err := client.CreateTask(context.Background(), &createTaskRequest)
+	require.NoError(t, err)
 
 	getTaskRequest := taskspb.GetTaskRequest{
 		Name: createdTask.GetName(),

--- a/emulator_test.go
+++ b/emulator_test.go
@@ -324,8 +324,7 @@ func TestErrorTaskExecution(t *testing.T) {
 	// With the default retry backoff, we expect 4 calls within the first second:
 	// at t=0, 0.1, 0.3 (+0.2), 0.7 (+0.4) seconds (plus some buffer) ==> 4 calls
 	receivedRequest, err := awaitHttpRequest(receivedRequests)
-	require.NoError(t, err)
-	log.Println("Got 1 request")
+	require.NoError(t, err, "Should have received request 1")
 	assertHeadersMatch(
 		t,
 		map[string]string{
@@ -336,8 +335,7 @@ func TestErrorTaskExecution(t *testing.T) {
 	)
 
 	receivedRequest, err = awaitHttpRequest(receivedRequests)
-	require.NoError(t, err)
-	log.Println("Got 2 requests")
+	require.NoError(t, err, "Should have received request 2")
 	assertHeadersMatch(
 		t,
 		map[string]string{
@@ -348,8 +346,7 @@ func TestErrorTaskExecution(t *testing.T) {
 	)
 
 	receivedRequest, err = awaitHttpRequest(receivedRequests)
-	require.NoError(t, err)
-	log.Println("Got 3 requests")
+	require.NoError(t, err, "Should have received request 3")
 	assertHeadersMatch(
 		t,
 		map[string]string{
@@ -360,8 +357,7 @@ func TestErrorTaskExecution(t *testing.T) {
 	)
 
 	receivedRequest, err = awaitHttpRequest(receivedRequests)
-	require.NoError(t, err)
-	log.Println("Got 4 requests")
+	require.NoError(t, err, "Should have received request 4")
 	assertHeadersMatch(
 		t,
 		map[string]string{


### PR DESCRIPTION
Hi @aertje - long time no speak, apologies things have been a bit crazy here the last while.

I have a couple of issues / PRs to put through (starting with updating and finishing off #21).

Unfortunately when I went to update that today I was having some trouble getting it to build reliably on Actions (it was working fine locally). Don't know if you've been having that too, or if I was just unlucky. I think this PR should make the tests a bit less sensitive to timing issues and easier to debug if they fail - I've run it a few times in my account and it's working consistently for me.