### PR TITLE
Fix staticcheck errors

### DIFF
--- a/emulator_test.go
+++ b/emulator_test.go
@@ -24,9 +24,7 @@ import (
 	"google.golang.org/api/option"
 	taskspb "google.golang.org/genproto/googleapis/cloud/tasks/v2"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	grpcCodes "google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	grpcStatus "google.golang.org/grpc/status"
 )
 
@@ -57,6 +55,9 @@ func setUp(t *testing.T, options ServerOptions) (*grpc.Server, *Client) {
 	clientOpt := option.WithGRPCConn(conn)
 
 	client, err := NewClient(context.Background(), clientOpt)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	return serv, client
 }
@@ -248,8 +249,8 @@ func TestGetQueueNeverExisted(t *testing.T) {
 	gettedQueue, err := client.GetQueue(context.Background(), &getQueueRequest)
 
 	assert.Nil(t, gettedQueue)
-	st, _ := status.FromError(err)
-	assert.Equal(t, codes.NotFound, st.Code())
+	st, _ := grpcStatus.FromError(err)
+	assert.Equal(t, grpcCodes.NotFound, st.Code())
 }
 
 func TestGetQueuePreviouslyExisted(t *testing.T) {
@@ -273,8 +274,8 @@ func TestGetQueuePreviouslyExisted(t *testing.T) {
 	gettedQueue, err := client.GetQueue(context.Background(), &getQueueRequest)
 
 	assert.Nil(t, gettedQueue)
-	st, _ := status.FromError(err)
-	assert.Equal(t, codes.NotFound, st.Code())
+	st, _ := grpcStatus.FromError(err)
+	assert.Equal(t, grpcCodes.NotFound, st.Code())
 }
 
 func TestPurgeQueueDoesNotReleaseTaskNamesByDefault(t *testing.T) {
@@ -375,6 +376,7 @@ func TestPurgeQueueOptionallyPerformsHardReset(t *testing.T) {
 	// Verify that it has now sent the request from the new task
 	receivedRequest, err := awaitHttpRequest(receivedRequests)
 	require.NotNil(t, receivedRequest, "Request was received")
+	require.NoError(t, err)
 	// Note that the execution count is reset to 0
 	assertHeadersMatch(
 		t,

--- a/oidc_internal_test.go
+++ b/oidc_internal_test.go
@@ -67,7 +67,7 @@ func TestOpenIdJWKSHttpHandler(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.Code)
 
-	expires, err := time.Parse(http.TimeFormat, resp.HeaderMap.Get("Expires"))
+	expires, err := time.Parse(http.TimeFormat, resp.Result().Header.Get("Expires"))
 	require.NoError(t, err)
 	assertRoughTimestamp(t, 24*time.Hour, expires.Unix(), "Expect future expires")
 
@@ -133,7 +133,7 @@ func assertRoughTimestamp(t *testing.T, expectOffset time.Duration, timestamp in
 }
 
 func parseJSONResponse(t *testing.T, resp *httptest.ResponseRecorder) map[string]interface{} {
-	assert.Equal(t, "application/json", resp.HeaderMap.Get("Content-Type"))
+	assert.Equal(t, "application/json", resp.Result().Header.Get("Content-Type"))
 
 	var body map[string]interface{}
 	err := json.Unmarshal(resp.Body.Bytes(), &body)
@@ -151,5 +151,4 @@ func performRequest(method string, url string, handler func(w http.ResponseWrite
 	http.HandlerFunc(handler).ServeHTTP(resp, req)
 
 	return resp
-
 }

--- a/task.go
+++ b/task.go
@@ -150,7 +150,6 @@ func setInitialTaskState(taskState *tasks.Task, queueName string) {
 			}
 
 			hostURL, err := url.Parse(host)
-
 			if err != nil {
 				panic(err)
 			}
@@ -397,7 +396,7 @@ func (task *Task) Delete() {
 func (task *Task) Schedule() {
 	scheduled, _ := ptypes.Timestamp(task.state.GetScheduleTime())
 
-	fromNow := scheduled.Sub(time.Now())
+	fromNow := time.Until(scheduled)
 
 	go func() {
 		select {


### PR DESCRIPTION
Minor cleanup. Fix static check reported errors.

output from staticcheck before:

```
emulator_test.go:27:2: package "google.golang.org/grpc/codes" is being imported more than once (ST1019)
	emulator_test.go:28:2: other import of "google.golang.org/grpc/codes"
emulator_test.go:29:2: package "google.golang.org/grpc/status" is being imported more than once (ST1019)
	emulator_test.go:30:2: other import of "google.golang.org/grpc/status"
emulator_test.go:59:2: this value of err is never used (SA4006)
emulator_test.go:376:2: this value of err is never used (SA4006)
oidc_internal_test.go:70:46: resp.HeaderMap has been deprecated since Go 1.11 and an alternative has been available since Go 1.7: HeaderMap exists for historical compatibility and should not be used. To access the headers returned by a handler, use the Response.Header map as returned by the Result method.  (SA1019)
oidc_internal_test.go:136:38: resp.HeaderMap has been deprecated since Go 1.11 and an alternative has been available since Go 1.7: HeaderMap exists for historical compatibility and should not be used. To access the headers returned by a handler, use the Response.Header map as returned by the Result method.  (SA1019)
task.go:400:13: should use time.Until instead of t.Sub(time.Now()) (S1024)
```