### PR TITLE
Add subject to the default OIDC token

### DIFF
--- a/oidc.go
+++ b/oidc.go
@@ -77,6 +77,7 @@ func createOIDCToken(serviceAccountEmail string, handlerUrl string) string {
 		Email:         serviceAccountEmail,
 		EmailVerified: true,
 		StandardClaims: jwt.StandardClaims{
+			Subject:   serviceAccountEmail,
 			Audience:  handlerUrl,
 			Issuer:    OpenIDConfig.IssuerURL,
 			IssuedAt:  now.Unix(),

--- a/oidc_internal_test.go
+++ b/oidc_internal_test.go
@@ -26,6 +26,7 @@ func TestCreateOIDCTokenSetsCorrectData(t *testing.T) {
 	assert.Equal(t, "http://my.service/foo?bar=v", claims.Audience, "Specifies audience")
 	assert.Equal(t, OpenIDConfig.IssuerURL, claims.Issuer, "Specifies issuer")
 	assert.Equal(t, "foobar@service.com", claims.Email, "Specifies email")
+	assert.Equal(t, "foobar@service.com", claims.Subject, "Specifies subject")
 	assert.True(t, claims.EmailVerified, "Specifies email")
 	assertRoughTimestamp(t, 0*time.Second, claims.IssuedAt, "Issued now")
 	assertRoughTimestamp(t, 0*time.Second, claims.NotBefore, "Not before now")


### PR DESCRIPTION
The subject is a required field on an ID token. This just passes the serviceAccountEmail as the subject. This adds a public subject which is locally unique but consistent for all clients https://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes

Fixes #71