### PR TITLE
Allow env vars on start

### DIFF
--- a/emulator.go
+++ b/emulator.go
@@ -392,7 +392,7 @@ func main() {
 
 	flag.Parse()
 
-	if len(initialQueues) == 0 {
+	if len(initialQueues) == 0 && os.Getenv("INITIAL_QUEUES") != "" {
 		initialQueues = strings.Split(os.Getenv("INITIAL_QUEUES"), ",")
 	}
 

--- a/emulator.go
+++ b/emulator.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -361,13 +362,36 @@ func createInitialQueue(emulatorServer *Server, name string) {
 }
 
 func main() {
+	defaultHost := "localhost"
+	if os.Getenv("HOST") != "" {
+		defaultHost = os.Getenv("HOST")
+	}
+	host := flag.String("host", defaultHost, "The host name")
+
+	defaultPort := "8123"
+	if os.Getenv("PORT") != "" {
+		defaultPort = os.Getenv("PORT")
+	}
+	port := flag.String("port", defaultPort, "The port")
+
+	defaultOpenIdIssuer := ""
+	if os.Getenv("OPENID_ISSUER") != "" {
+		defaultOpenIdIssuer = os.Getenv("OPENID_ISSUER")
+	}
+	openidIssuer := flag.String("openid-issuer", defaultOpenIdIssuer, "URL to serve the OpenID configuration on, if required")
+
+	defaultHardResetOnPurgeQueue := false
+	if os.Getenv("HARD_RESET_ON_PURGE_QUEUE") == "true" {
+		defaultHardResetOnPurgeQueue = true
+	}
+	hardResetOnPurgeQueue := flag.Bool("hard-reset-on-purge-queue", defaultHardResetOnPurgeQueue, "Set to force the 'Purge Queue' call to perform a hard reset of all state (differs from production)")
+
 	var initialQueues arrayFlags
 
-	host := flag.String("host", "localhost", "The host name")
-	port := flag.String("port", "8123", "The port")
-	openidIssuer := flag.String("openid-issuer", "", "URL to serve the OpenID configuration on, if required")
-	hardResetOnPurgeQueue := flag.Bool("hard-reset-on-purge-queue", false, "Set to force the 'Purge Queue' call to perform a hard reset of all state (differs from production)")
-
+	envVarInitialQueues := os.Getenv("INITIAL_QUEUES")
+	if envVarInitialQueues != "" {
+		initialQueues = strings.Split(envVarInitialQueues, ",")
+	}
 	flag.Var(&initialQueues, "queue", "A queue to create on startup (repeat as required)")
 
 	flag.Parse()

--- a/emulator.go
+++ b/emulator.go
@@ -388,13 +388,13 @@ func main() {
 
 	var initialQueues arrayFlags
 
-	envVarInitialQueues := os.Getenv("INITIAL_QUEUES")
-	if envVarInitialQueues != "" {
-		initialQueues = strings.Split(envVarInitialQueues, ",")
-	}
 	flag.Var(&initialQueues, "queue", "A queue to create on startup (repeat as required)")
 
 	flag.Parse()
+
+	if len(initialQueues) == 0 {
+		initialQueues = strings.Split(os.Getenv("INITIAL_QUEUES"), ",")
+	}
 
 	if *openidIssuer != "" {
 		srv, err := configureOpenIdIssuer(*openidIssuer)

--- a/readme.MD
+++ b/readme.MD
@@ -35,6 +35,17 @@ go run ./ -host localhost \
   -queue projects/dev/locations/here/queues/anotherq
 ```
 
+Or, instead of passing in flags, you can set environment variables. If you pass both, the flag will take precedence over the environment variable.
+
+```sh
+export PORT=8124
+export HOST=localhost
+export HARD_RESET_ON_PURGE=true
+export INITIAL_QUEUES=projects/dev/locations/here/queues/1,projects/dev/locations/here/queues/2
+export OPENID_ISSUER=http://localhost:8080
+go run ./
+```
+
 Once running, you connect to it using the standard google cloud tasks GRPC libraries.
 
 ### Docker
@@ -64,7 +75,7 @@ gcloud-tasks-emulator:
 
 
 ## App Engine
-If you want to use it to make calls to a local [App Engine emulator](https://cloud.google.com/appengine/docs/standard/python3/testing-and-deploying-your-app#local-dev-server) instance, you'll need to set the appropriate environment variable, e.g.:  
+If you want to use it to make calls to a local [App Engine emulator](https://cloud.google.com/appengine/docs/standard/python3/testing-and-deploying-your-app#local-dev-server) instance, you'll need to set the appropriate environment variable, e.g.:
 ```sh
 export APP_ENGINE_EMULATOR_HOST=http://localhost:8080
 ```
@@ -216,7 +227,7 @@ $client = new CloudTasksClient([
                 ]
             ]
         ]);
-	
+
 $http = new HttpRequest();
 $http->setHttpMethod(HttpMethod::GET)->setUrl('https://google.com');
 


### PR DESCRIPTION
Modifies the entrypoint function to accept env variables. 

It's not possible to pass flags to a service in Github Actions, but it is possible to pass env variables, so this facilitates that use case.