### PR TITLE
shell script for running emulator with options pulled from environment vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,16 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-
 RUN go build -o emulator .
-
 
 FROM alpine:latest
 
 LABEL org.opencontainers.image.source=https://github.com/aertje/cloud-tasks-emulator
 
-ENTRYPOINT ["/emulator"]
-
 WORKDIR /
 
 COPY --from=builder /app/emulator .
+COPY --from=builder /app/emulator_from_env.sh .
+RUN chmod +x emulator_from_env.sh
+
+ENTRYPOINT ["./emulator"]

--- a/emulator_from_env.sh
+++ b/emulator_from_env.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+RUN_CMD="/emulator"
+
+if [ -n "$HOST" ]; then
+  RUN_CMD="$RUN_CMD -host=$HOST"
+fi
+
+if [ -n "$PORT" ]; then
+  RUN_CMD="$RUN_CMD -port=$PORT"
+fi
+
+if [ -n "$HARD_RESET_ON_PURGE_QUEUE" ]; then
+  RUN_CMD="$RUN_CMD -hard_reset_on_purge_queue=$HARD_RESET_ON_PURGE_QUEUE"
+fi
+
+if [ -n "$OPENID_ISSUER" ]; then
+  RUN_CMD="$RUN_CMD -openid_issuer=$OPENID_ISSUER"
+fi
+
+if [ -n "$INITIAL_QUEUES" ]; then
+  IFS=","
+  set -- $INITIAL_QUEUES
+  for i in "$@"; do
+    RUN_CMD="$RUN_CMD -queue=$i"
+  done
+fi
+
+`$RUN_CMD`

--- a/readme.MD
+++ b/readme.MD
@@ -35,6 +35,18 @@ go run ./ -host localhost \
   -queue projects/dev/locations/here/queues/anotherq
 ```
 
+Alternatively, you can define environment variables and then run the shell script `./emulator_from_env.sh` to start the emulator. The following environment variables are supported:
+
+ ```sh
+ export PORT=8124
+ export HOST=localhost
+ export HARD_RESET_ON_PURGE=true
+ export INITIAL_QUEUES=projects/dev/locations/here/queues/1,projects/dev/locations/here/queues/2
+ export OPENID_ISSUER=http://localhost:8080
+
+./emulator_from_env.sh
+ ```
+
 Once running, you connect to it using the standard google cloud tasks GRPC libraries.
 
 ### Docker
@@ -64,7 +76,7 @@ gcloud-tasks-emulator:
 
 
 ## App Engine
-If you want to use it to make calls to a local [App Engine emulator](https://cloud.google.com/appengine/docs/standard/python3/testing-and-deploying-your-app#local-dev-server) instance, you'll need to set the appropriate environment variable, e.g.:  
+If you want to use it to make calls to a local [App Engine emulator](https://cloud.google.com/appengine/docs/standard/python3/testing-and-deploying-your-app#local-dev-server) instance, you'll need to set the appropriate environment variable, e.g.:
 ```sh
 export APP_ENGINE_EMULATOR_HOST=http://localhost:8080
 ```
@@ -216,7 +228,7 @@ $client = new CloudTasksClient([
                 ]
             ]
         ]);
-	
+
 $http = new HttpRequest();
 $http->setHttpMethod(HttpMethod::GET)->setUrl('https://google.com');
 


### PR DESCRIPTION
script can be used as an secondary entrypoint for running the docker container.

see discussion in PR: #80 


