### PR TITLE
Update NodeJS example to work with newest dependencies. Fixes #92

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -246,12 +246,12 @@ $response = $this->client->createTask($queuePath, $task);
 The following example can be used for JavaScript.
 ```js
 import { CloudTasksClient } from '@google-cloud/tasks';
-import { credentials } from '@grpc/grpc-js';
+import { ChannelCredentials } from 'google-gax';
 
 const client = new CloudTasksClient({
   port: 8123,
   servicePath: 'localhost',
-  sslCreds: credentials.createInsecure(),
+  sslCreds: ChannelCredentials.createInsecure(),
 });
 
 const parent = 'projects/my-sandbox/locations/us-central1';


### PR DESCRIPTION
Fixes the following error when connecting to the emulator with `"@google-cloud/tasks": "^5.0.0"`. It's not an issue with the emulator, but Google modules got updated, and the NodeJS example was out of date. 

```js
     TypeError: Channel credentials must be a ChannelCredentials object
      at new ChannelImplementation (node_modules\google-gax\node_modules\@grpc\grpc-js\build\src\channel.js:29:19)
      at new Client (node_modules\google-gax\node_modules\@grpc\grpc-js\build\src\client.js:65:36)
      at new ServiceClientImpl (node_modules\google-gax\node_modules\@grpc\grpc-js\build\src\make-client.js:58:5)
      at GrpcClient.createStub (node_modules\google-gax\build\src\grpc.js:345:22)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

The root cause is that in `node_modules\google-gax\node_modules\@grpc\grpc-js\build\src\channel.js:29:19` the credentials object is checked to be an instance of `google-gax/ChannelCredentials`

However, in the README of this repository, the `@grpc/grpc-js` library is used to create the CredentialsObject. 

```js
import { credentials } from '@grpc/grpc-js';

const client = new CloudTasksClient({
  port: 8123,
  servicePath: 'localhost',
  sslCreds: credentials.createInsecure(),
});
```

Thus, the check in `node_modules\google-gax\node_modules\@grpc\grpc-js\build\src\channel.js:29:19` fails because the given credentials object has a different prototype hierarchy.

I fixed it by using `ChannelCredentials` from `google-gax` module. No need to install or pin any dependency versions.

```js
import { ChannelCredentials } from 'google-gax';

const client = new CloudTasksClient({
  port: 8123,
  servicePath: 'localhost',
  sslCreds: ChannelCredentials.createInsecure(),
});
```