### PR TITLE
docs: Update go example

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -185,18 +185,20 @@ In Go it would go something like this.
 import (
 	"context"
 
-	taskspb "google.golang.org/genproto/googleapis/cloud/tasks/v2"
+	taskspb "cloud.google.com/go/cloudtasks/apiv2/cloudtaskspb"
 	"google.golang.org/grpc"
 )
 
-conn, _ := grpc.Dial("localhost:8123", grpc.WithInsecure())
+conn, _ := grpc.Dial("localhost:8123", grpc.WithTransportCredentials(insecure.NewCredentials()))
 clientOpt := option.WithGRPCConn(conn)
 client, _ := NewClient(context.Background(), clientOpt)
 
 parent := "projects/test-project/locations/us-central1"
 createQueueRequest := taskspb.CreateQueueRequest{
     Parent: parent,
-    Queue: parent + "/queues/test",
+      Queue: &taskspb.Queue{
+        Name: parent + "/queues/test",
+      },
 }
 
 createQueueResp, _ := client.CreateQueue(context.Background(), &createQueueRequest)


### PR DESCRIPTION
Thank you great work! I noticed some deprecated warnings.

- "google.golang.org/genproto/googleapis/cloud/tasks/v2" is deprecated. You should use "cloud.google.com/go/cloudtasks/apiv2/cloudtaskspb"
  - Details: https://pkg.go.dev/google.golang.org/genproto@v0.0.0-20250102185135-69823020774d/googleapis/cloud/tasks/v2
- `grpc.WithInsecure()` is deprecated. You should use "google.golang.org/grpc/credentials/insecure"
  - Details: https://pkg.go.dev/google.golang.org/grpc@v1.69.2#WithInsecure