### PR TITLE
Make optionality explicit in engine state via maybe.Maybe

### DIFF
--- a/internal/engine/dispatch.go
+++ b/internal/engine/dispatch.go
@@ -55,7 +55,7 @@ var (
 // dispatch), so nothing is added. Only the no-response case was captured as a
 // timeout; other no-response modes (e.g. a refused connection) are unobserved
 // and treated the same.
-func addOptionalRetryHeaders(injected map[string]string, p retryHeaderPolicy, previous maybe.Maybe[int]) {
+func addOptionalRetryHeaders(injected map[string]string, p retryHeaderPolicy, previous maybe.M[int]) {
 	code, ok := previous.Get()
 	if !ok {
 		return
@@ -125,7 +125,7 @@ func updateStateAfterDispatch(task *Task, statusCode int) {
 	rpcCodeName := toCodeName(rpcCode)
 
 	// Complete the in-flight LastAttempt with its response fields. LastAttempt is
-	// a value-typed Maybe, so State() snapshots already hold their own copy of the
+	// a value-typed maybe.M, so State() snapshots already hold their own copy of the
 	// Attempt; storing the completed value here cannot mutate a snapshot the gRPC
 	// edge is reading (unlocked) via taskToProto.
 	attempt := task.state.LastAttempt.OrZero()

--- a/internal/engine/dispatch.go
+++ b/internal/engine/dispatch.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aertje/cloud-tasks-emulator/v2/internal/maybe"
 	"github.com/aertje/cloud-tasks-emulator/v2/internal/oidc"
 )
 
@@ -47,18 +48,23 @@ var (
 )
 
 // addOptionalRetryHeaders adds the two retry-only dispatch headers to injected,
-// keyed off how the previous attempt failed. previousResponseCode is the prior
-// attempt's raw HTTP status: >0 means it returned that status; <0 means it got
-// no response (a transport failure or dispatch-deadline timeout); 0 means there
-// was no previous attempt (the first dispatch), so nothing is added. Only the
-// no-response case was captured as a timeout; other no-response modes (e.g. a
-// refused connection) are unobserved and treated the same.
-func addOptionalRetryHeaders(injected map[string]string, p retryHeaderPolicy, previousResponseCode int) {
+// keyed off how the previous attempt failed. previous is the prior attempt's
+// raw HTTP status: a positive value means it returned that status; a negative
+// value means it got no response (a transport failure or dispatch-deadline
+// timeout); an absent value means there was no previous attempt (the first
+// dispatch), so nothing is added. Only the no-response case was captured as a
+// timeout; other no-response modes (e.g. a refused connection) are unobserved
+// and treated the same.
+func addOptionalRetryHeaders(injected map[string]string, p retryHeaderPolicy, previous maybe.Maybe[int]) {
+	code, ok := previous.Get()
+	if !ok {
+		return
+	}
 	switch {
-	case previousResponseCode > 0:
-		injected[p.prefix+"TaskPreviousResponse"] = strconv.Itoa(previousResponseCode)
+	case code > 0:
+		injected[p.prefix+"TaskPreviousResponse"] = strconv.Itoa(code)
 		injected[p.prefix+"TaskRetryReason"] = p.responseReason
-	case previousResponseCode < 0:
+	case code < 0:
 		injected[p.prefix+"TaskPreviousResponse"] = p.timeoutPrevious
 		injected[p.prefix+"TaskRetryReason"] = p.timeoutReason
 	}
@@ -70,10 +76,10 @@ func updateStateForReschedule(task *Task) {
 
 	retryConfig := task.queue.state.RetryConfig
 
-	doubling := min(task.state.DispatchCount-1, retryConfig.MaxDoublings)
-	backoff := min(retryConfig.MinBackoff*time.Duration(1<<uint32(doubling)), retryConfig.MaxBackoff)
+	doubling := min(task.state.DispatchCount-1, retryConfig.MaxDoublings.OrZero())
+	backoff := min(retryConfig.MinBackoff.OrZero()*time.Duration(1<<uint32(doubling)), retryConfig.MaxBackoff.OrZero())
 
-	task.state.ScheduleTime = task.state.ScheduleTime.Add(backoff)
+	task.state.ScheduleTime = maybe.Some(task.state.ScheduleTime.OrZero().Add(backoff))
 }
 
 func updateStateForDispatch(task *Task) TaskState {
@@ -84,23 +90,24 @@ func updateStateForDispatch(task *Task) TaskState {
 
 	// Capture the previous attempt's response code before its Attempt is
 	// overwritten below, so this dispatch can report it via
-	// X-*-TaskPreviousResponse (retries only).
-	previousResponseCode := 0
-	if prev := task.state.LastAttempt; prev != nil {
+	// X-*-TaskPreviousResponse (retries only). Absent when there was no previous
+	// attempt (the first dispatch).
+	previousResponseCode := maybe.None[int]()
+	if prev, ok := task.state.LastAttempt.Get(); ok {
 		previousResponseCode = prev.ResponseCode
 	}
 
-	task.state.LastAttempt = &Attempt{
+	task.state.LastAttempt = maybe.Some(Attempt{
 		ScheduleTime: task.state.ScheduleTime,
-		DispatchTime: dispatchTime,
-	}
+		DispatchTime: maybe.Some(dispatchTime),
+	})
 
 	task.state.DispatchCount++
 
-	if task.state.FirstAttempt == nil {
-		task.state.FirstAttempt = &Attempt{
-			DispatchTime: dispatchTime,
-		}
+	if !task.state.FirstAttempt.IsPresent() {
+		task.state.FirstAttempt = maybe.Some(Attempt{
+			DispatchTime: maybe.Some(dispatchTime),
+		})
 	}
 
 	// PreviousResponseCode rides on the returned snapshot only, not the retained
@@ -117,17 +124,18 @@ func updateStateAfterDispatch(task *Task, statusCode int) {
 	rpcCode := toRPCStatusCode(statusCode)
 	rpcCodeName := toCodeName(rpcCode)
 
-	// Copy-on-write: publish a fresh Attempt rather than mutating the one already
-	// handed out through State() snapshots, whose *Attempt is shared shallowly
-	// and read (unlocked) by the gRPC edge via taskToProto.
-	attempt := *task.state.LastAttempt
-	attempt.ResponseTime = time.Now()
-	attempt.ResponseCode = statusCode
-	attempt.ResponseStatus = &AttemptStatus{
+	// Complete the in-flight LastAttempt with its response fields. LastAttempt is
+	// a value-typed Maybe, so State() snapshots already hold their own copy of the
+	// Attempt; storing the completed value here cannot mutate a snapshot the gRPC
+	// edge is reading (unlocked) via taskToProto.
+	attempt := task.state.LastAttempt.OrZero()
+	attempt.ResponseTime = maybe.Some(time.Now())
+	attempt.ResponseCode = maybe.Some(statusCode)
+	attempt.ResponseStatus = maybe.Some(AttemptStatus{
 		Code:    rpcCode,
 		Message: fmt.Sprintf("%s(%d): HTTP status code %d", rpcCodeName, rpcCode, statusCode),
-	}
-	task.state.LastAttempt = &attempt
+	})
+	task.state.LastAttempt = maybe.Some(attempt)
 
 	// Only an attempt that actually received an HTTP response counts: a transport
 	// failure or dispatch-deadline timeout (statusCode < 0) received none. This
@@ -158,7 +166,7 @@ func (task *Task) reschedule(retry bool, statusCode int) {
 
 	task.stateMutex.Lock()
 	dispatchCount := task.state.DispatchCount
-	maxAttempts := task.queue.state.RetryConfig.MaxAttempts
+	maxAttempts := task.queue.state.RetryConfig.MaxAttempts.OrZero()
 	task.stateMutex.Unlock()
 
 	if dispatchCount >= maxAttempts {
@@ -223,7 +231,7 @@ func insecureTransport() *http.Transport {
 // is read concurrently by gRPC handlers. ctx bounds the request's lifetime (see
 // Queue.ctx); DispatchDeadline is still enforced via the http.Client timeout.
 func dispatch(ctx context.Context, state TaskState, oidcCfg oidc.Config, logger *slog.Logger, transport http.RoundTripper) int {
-	client := &http.Client{Timeout: state.DispatchDeadline, Transport: transport}
+	client := &http.Client{Timeout: state.DispatchDeadline.OrZero(), Transport: transport}
 
 	nameParts, ok := parseTaskName(state.Name)
 	if !ok {
@@ -239,7 +247,7 @@ func dispatch(ctx context.Context, state TaskState, oidcCfg oidc.Config, logger 
 	// response (state.ResponseCount). See TaskState.ExecutionCount.
 	headerHTTPExecutionCount := fmt.Sprintf("%v", state.ExecutionCount)
 	headerAppEngineExecutionCount := fmt.Sprintf("%v", state.ResponseCount)
-	headerTaskETA := fmt.Sprintf("%f", float64(state.ScheduleTime.UnixNano())/1e9)
+	headerTaskETA := fmt.Sprintf("%f", float64(state.ScheduleTime.OrZero().UnixNano())/1e9)
 
 	var (
 		method     string
@@ -250,11 +258,12 @@ func dispatch(ctx context.Context, state TaskState, oidcCfg oidc.Config, logger 
 	)
 
 	switch {
-	case state.HTTPRequest != nil:
-		method = state.HTTPRequest.Method
-		url = state.HTTPRequest.URL
-		body = state.HTTPRequest.Body
-		srcHeaders = state.HTTPRequest.Headers
+	case state.HTTPRequest.IsPresent():
+		hr, _ := state.HTTPRequest.Get()
+		method = hr.Method.OrZero()
+		url = hr.URL
+		body = hr.Body
+		srcHeaders = hr.Headers
 
 		// Headers as per https://cloud.google.com/tasks/docs/creating-http-target-tasks#handler
 		injected = map[string]string{
@@ -267,7 +276,7 @@ func dispatch(ctx context.Context, state TaskState, oidcCfg oidc.Config, logger 
 		}
 		addOptionalRetryHeaders(injected, httpRetryPolicy, state.PreviousResponseCode)
 
-		if auth := state.HTTPRequest.OIDCToken; auth != nil {
+		if auth, ok := hr.OIDCToken.Get(); ok {
 			tokenStr, err := oidcCfg.CreateToken(auth.ServiceAccountEmail, url, auth.Audience)
 			if err != nil {
 				logger.Error("dispatch: create OIDC token", "task", state.Name, "err", err)
@@ -275,11 +284,11 @@ func dispatch(ctx context.Context, state TaskState, oidcCfg oidc.Config, logger 
 			}
 			injected["Authorization"] = "Bearer " + tokenStr
 		}
-	case state.AppEngineHTTPRequest != nil:
-		ae := state.AppEngineHTTPRequest
+	case state.AppEngineHTTPRequest.IsPresent():
+		ae, _ := state.AppEngineHTTPRequest.Get()
 
-		method = ae.Method
-		url = ae.AppEngineRouting.Host + ae.RelativeURI
+		method = ae.Method.OrZero()
+		url = ae.AppEngineRouting.OrZero().Host + ae.RelativeURI.OrZero()
 		body = ae.Body
 		srcHeaders = ae.Headers
 

--- a/internal/engine/dispatch.go
+++ b/internal/engine/dispatch.go
@@ -261,9 +261,9 @@ func dispatch(ctx context.Context, state TaskState, oidcCfg oidc.Config, logger 
 	case state.HTTPRequest.IsPresent():
 		hr, _ := state.HTTPRequest.Get()
 		method = hr.Method.OrZero()
-		url = hr.URL
-		body = hr.Body
-		srcHeaders = hr.Headers
+		url = hr.URL.OrZero()
+		body = hr.Body.OrZero()
+		srcHeaders = hr.Headers.OrZero()
 
 		// Headers as per https://cloud.google.com/tasks/docs/creating-http-target-tasks#handler
 		injected = map[string]string{
@@ -277,7 +277,7 @@ func dispatch(ctx context.Context, state TaskState, oidcCfg oidc.Config, logger 
 		addOptionalRetryHeaders(injected, httpRetryPolicy, state.PreviousResponseCode)
 
 		if auth, ok := hr.OIDCToken.Get(); ok {
-			tokenStr, err := oidcCfg.CreateToken(auth.ServiceAccountEmail, url, auth.Audience)
+			tokenStr, err := oidcCfg.CreateToken(auth.ServiceAccountEmail, url, auth.Audience.OrZero())
 			if err != nil {
 				logger.Error("dispatch: create OIDC token", "task", state.Name, "err", err)
 				return -1
@@ -288,9 +288,9 @@ func dispatch(ctx context.Context, state TaskState, oidcCfg oidc.Config, logger 
 		ae, _ := state.AppEngineHTTPRequest.Get()
 
 		method = ae.Method.OrZero()
-		url = ae.AppEngineRouting.OrZero().Host + ae.RelativeURI.OrZero()
-		body = ae.Body
-		srcHeaders = ae.Headers
+		url = ae.AppEngineRouting.OrZero().Host.OrZero() + ae.RelativeURI.OrZero()
+		body = ae.Body.OrZero()
+		srcHeaders = ae.Headers.OrZero()
 
 		// These headers are only set on dispatch, see https://cloud.google.com/tasks/docs/reference/rpc/google.cloud.tasks.v2#google.cloud.tasks.v2.AppEngineHttpRequest
 		injected = map[string]string{

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -621,10 +621,11 @@ func (e *Engine) CreateTask(ctx context.Context, parent string, ts TaskState) (*
 	// deliberately not fully parsed here (an invalid percent-escape, say, is
 	// accepted and only fails when the task is dispatched).
 	if hr, ok := ts.HTTPRequest.Get(); ok {
-		if hr.URL == "" {
+		url := hr.URL.OrZero()
+		if url == "" {
 			return nil, TaskState{}, ErrHTTPRequestURLRequired
 		}
-		if !strings.HasPrefix(hr.URL, "http://") && !strings.HasPrefix(hr.URL, "https://") {
+		if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
 			return nil, TaskState{}, ErrHTTPRequestURLScheme
 		}
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -620,11 +620,11 @@ func (e *Engine) CreateTask(ctx context.Context, parent string, ts TaskState) (*
 	// shallowly: it must be non-empty and start with http:// or https://. It is
 	// deliberately not fully parsed here (an invalid percent-escape, say, is
 	// accepted and only fails when the task is dispatched).
-	if ts.HTTPRequest != nil {
-		if ts.HTTPRequest.URL == "" {
+	if hr, ok := ts.HTTPRequest.Get(); ok {
+		if hr.URL == "" {
 			return nil, TaskState{}, ErrHTTPRequestURLRequired
 		}
-		if !strings.HasPrefix(ts.HTTPRequest.URL, "http://") && !strings.HasPrefix(ts.HTTPRequest.URL, "https://") {
+		if !strings.HasPrefix(hr.URL, "http://") && !strings.HasPrefix(hr.URL, "https://") {
 			return nil, TaskState{}, ErrHTTPRequestURLScheme
 		}
 	}

--- a/internal/engine/engine_internal_test.go
+++ b/internal/engine/engine_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aertje/cloud-tasks-emulator/v2/internal/maybe"
 	"github.com/aertje/cloud-tasks-emulator/v2/internal/oidc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -139,12 +140,16 @@ func createRunningQueue(t *testing.T, e *Engine) *Queue {
 }
 
 // httpTaskState builds a valid HTTP task state, optionally with a fixed name and
-// schedule time (zero schedule dispatches immediately).
+// schedule time (zero schedule leaves it unset, so it dispatches immediately).
 func httpTaskState(name string, schedule time.Time) TaskState {
+	scheduleTime := maybe.None[time.Time]()
+	if !schedule.IsZero() {
+		scheduleTime = maybe.Some(schedule)
+	}
 	return TaskState{
 		Name:         name,
-		ScheduleTime: schedule,
-		HTTPRequest:  &HTTPRequest{URL: "http://example.test/"},
+		ScheduleTime: scheduleTime,
+		HTTPRequest:  maybe.Some(HTTPRequest{URL: "http://example.test/"}),
 	}
 }
 
@@ -209,25 +214,25 @@ func TestBackoffReschedule(t *testing.T) {
 	}{
 		{
 			name:          "first retry uses min backoff",
-			retry:         RetryConfig{MinBackoff: 100 * time.Millisecond, MaxBackoff: time.Hour, MaxDoublings: 16},
+			retry:         RetryConfig{MinBackoff: maybe.Some(100 * time.Millisecond), MaxBackoff: maybe.Some(time.Hour), MaxDoublings: maybe.Some[int32](16)},
 			dispatchCount: 1,
 			wantBackoff:   100 * time.Millisecond,
 		},
 		{
 			name:          "doubles each attempt",
-			retry:         RetryConfig{MinBackoff: 100 * time.Millisecond, MaxBackoff: time.Hour, MaxDoublings: 16},
+			retry:         RetryConfig{MinBackoff: maybe.Some(100 * time.Millisecond), MaxBackoff: maybe.Some(time.Hour), MaxDoublings: maybe.Some[int32](16)},
 			dispatchCount: 3, // doubling = 2 => x4
 			wantBackoff:   400 * time.Millisecond,
 		},
 		{
 			name:          "capped by max doublings",
-			retry:         RetryConfig{MinBackoff: 1 * time.Second, MaxBackoff: time.Hour, MaxDoublings: 1},
+			retry:         RetryConfig{MinBackoff: maybe.Some(1 * time.Second), MaxBackoff: maybe.Some(time.Hour), MaxDoublings: maybe.Some[int32](1)},
 			dispatchCount: 5, // doubling capped at 1 => x2
 			wantBackoff:   2 * time.Second,
 		},
 		{
 			name:          "capped by max backoff",
-			retry:         RetryConfig{MinBackoff: 1 * time.Second, MaxBackoff: 3 * time.Second, MaxDoublings: 16},
+			retry:         RetryConfig{MinBackoff: maybe.Some(1 * time.Second), MaxBackoff: maybe.Some(3 * time.Second), MaxDoublings: maybe.Some[int32](16)},
 			dispatchCount: 10, // would be huge, capped at 3s
 			wantBackoff:   3 * time.Second,
 		},
@@ -236,10 +241,10 @@ func TestBackoffReschedule(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			task := &Task{
 				queue: &Queue{state: QueueState{RetryConfig: tc.retry}},
-				state: TaskState{ScheduleTime: baseSchedule, DispatchCount: tc.dispatchCount},
+				state: TaskState{ScheduleTime: maybe.Some(baseSchedule), DispatchCount: tc.dispatchCount},
 			}
 			updateStateForReschedule(task)
-			assert.Equal(t, baseSchedule.Add(tc.wantBackoff), task.state.ScheduleTime)
+			assert.Equal(t, baseSchedule.Add(tc.wantBackoff), task.state.ScheduleTime.OrZero())
 		})
 	}
 }
@@ -441,7 +446,7 @@ func TestTaskRetriesUntilSuccess(t *testing.T) {
 	// Short backoff so the retries land quickly.
 	_, err := e.CreateQueue(ctx, "projects/p/locations/l", QueueState{
 		Name:        testParent,
-		RetryConfig: RetryConfig{MinBackoff: time.Millisecond, MaxBackoff: 10 * time.Millisecond, MaxAttempts: 100, MaxDoublings: 1},
+		RetryConfig: RetryConfig{MinBackoff: maybe.Some(time.Millisecond), MaxBackoff: maybe.Some(10 * time.Millisecond), MaxAttempts: maybe.Some[int32](100), MaxDoublings: maybe.Some[int32](1)},
 	})
 	require.NoError(t, err)
 
@@ -470,7 +475,7 @@ func TestTaskStopsAfterMaxAttempts(t *testing.T) {
 
 	_, err := e.CreateQueue(ctx, "projects/p/locations/l", QueueState{
 		Name:        testParent,
-		RetryConfig: RetryConfig{MinBackoff: time.Millisecond, MaxBackoff: 5 * time.Millisecond, MaxAttempts: 3, MaxDoublings: 1},
+		RetryConfig: RetryConfig{MinBackoff: maybe.Some(time.Millisecond), MaxBackoff: maybe.Some(5 * time.Millisecond), MaxAttempts: maybe.Some[int32](3), MaxDoublings: maybe.Some[int32](1)},
 	})
 	require.NoError(t, err)
 

--- a/internal/engine/engine_internal_test.go
+++ b/internal/engine/engine_internal_test.go
@@ -149,7 +149,7 @@ func httpTaskState(name string, schedule time.Time) TaskState {
 	return TaskState{
 		Name:         name,
 		ScheduleTime: scheduleTime,
-		HTTPRequest:  maybe.Some(HTTPRequest{URL: "http://example.test/"}),
+		HTTPRequest:  maybe.Some(HTTPRequest{URL: maybe.Some("http://example.test/")}),
 	}
 }
 

--- a/internal/engine/queue.go
+++ b/internal/engine/queue.go
@@ -89,22 +89,22 @@ func newQueue(state QueueState, oidcCfg oidc.Config, dispatcher Dispatcher, logg
 		name:                   state.Name,
 		state:                  state,
 		fire:                   make(chan *Task),
-		sem:                    make(chan struct{}, int(state.RateLimits.MaxConcurrentDispatches)),
+		sem:                    make(chan struct{}, int(state.RateLimits.MaxConcurrentDispatches.OrZero())),
 		ts:                     make(map[string]*Task),
 		onTaskDone:             onTaskDone,
 		oidcCfg:                oidcCfg,
 		dispatcher:             dispatcher,
 		logger:                 logger,
 		appEngineHost:          appEngineHost,
-		tokenBucket:            make(chan bool, state.RateLimits.MaxBurstSize),
-		maxDispatchesPerSecond: state.RateLimits.MaxDispatchesPerSecond,
+		tokenBucket:            make(chan bool, state.RateLimits.MaxBurstSize.OrZero()),
+		maxDispatchesPerSecond: state.RateLimits.MaxDispatchesPerSecond.OrZero(),
 		stopAll:                make(chan struct{}),
 		stopDispatch:           make(chan struct{}),
 		ctx:                    ctx,
 		cancel:                 cancel,
 	}
 	// Fill the token bucket
-	for i := 0; i < int(state.RateLimits.MaxBurstSize); i++ {
+	for i := 0; i < int(state.RateLimits.MaxBurstSize.OrZero()); i++ {
 		queue.tokenBucket <- true
 	}
 
@@ -141,28 +141,14 @@ func (queue *Queue) retireTask(task *Task) {
 }
 
 func setInitialQueueState(s *QueueState) {
-	if s.RateLimits.MaxDispatchesPerSecond == 0 {
-		s.RateLimits.MaxDispatchesPerSecond = 500.0
-	}
-	if s.RateLimits.MaxBurstSize == 0 {
-		s.RateLimits.MaxBurstSize = 100
-	}
-	if s.RateLimits.MaxConcurrentDispatches == 0 {
-		s.RateLimits.MaxConcurrentDispatches = 1000
-	}
+	s.RateLimits.MaxDispatchesPerSecond = s.RateLimits.MaxDispatchesPerSecond.Or(500.0)
+	s.RateLimits.MaxBurstSize = s.RateLimits.MaxBurstSize.Or(100)
+	s.RateLimits.MaxConcurrentDispatches = s.RateLimits.MaxConcurrentDispatches.Or(1000)
 
-	if s.RetryConfig.MaxAttempts == 0 {
-		s.RetryConfig.MaxAttempts = 100
-	}
-	if s.RetryConfig.MaxDoublings == 0 {
-		s.RetryConfig.MaxDoublings = 16
-	}
-	if s.RetryConfig.MinBackoff == 0 {
-		s.RetryConfig.MinBackoff = 100 * time.Millisecond
-	}
-	if s.RetryConfig.MaxBackoff == 0 {
-		s.RetryConfig.MaxBackoff = 3600 * time.Second
-	}
+	s.RetryConfig.MaxAttempts = s.RetryConfig.MaxAttempts.Or(100)
+	s.RetryConfig.MaxDoublings = s.RetryConfig.MaxDoublings.Or(16)
+	s.RetryConfig.MinBackoff = s.RetryConfig.MinBackoff.Or(100 * time.Millisecond)
+	s.RetryConfig.MaxBackoff = s.RetryConfig.MaxBackoff.Or(3600 * time.Second)
 
 	s.State = QueueRunStateRunning
 }

--- a/internal/engine/task.go
+++ b/internal/engine/task.go
@@ -148,39 +148,43 @@ func setInitialTaskState(s *TaskState, queueName string, appEngineHost string) {
 	// Some rather than mutated in place.
 	if hr, ok := s.HTTPRequest.Get(); ok {
 		hr.Method = hr.Method.Or(http.MethodPost)
-		if hr.Headers == nil {
-			hr.Headers = make(map[string]string)
+		headers := hr.Headers.OrZero()
+		if headers == nil {
+			headers = make(map[string]string)
 		}
 		// Cloud Tasks overrides any caller-supplied User-Agent.
-		hr.Headers["User-Agent"] = "Google-Cloud-Tasks"
+		headers["User-Agent"] = "Google-Cloud-Tasks"
+		hr.Headers = maybe.Some(headers)
 		s.HTTPRequest = maybe.Some(hr)
 	}
 
 	if ae, ok := s.AppEngineHTTPRequest.Get(); ok {
 		ae.Method = ae.Method.Or(http.MethodPost)
-		if ae.Headers == nil {
-			ae.Headers = make(map[string]string)
+		headers := ae.Headers.OrZero()
+		if headers == nil {
+			headers = make(map[string]string)
 		}
-		ae.Headers["User-Agent"] = "AppEngine-Google; (+http://code.google.com/appengine)"
+		headers["User-Agent"] = "AppEngine-Google; (+http://code.google.com/appengine)"
 
-		if len(ae.Body) > 0 {
+		if body := ae.Body.OrZero(); len(body) > 0 {
 			// HTTP field names are case-insensitive, so a caller-supplied
 			// "content-type" must suppress the default just as "Content-Type"
 			// would - otherwise the task carries two Content-Type headers, which
 			// Cloud Tasks does not allow (see conformance/golden/headers.json).
 			// The default itself is added under the canonical casing.
-			if !hasHeaderFold(ae.Headers, "Content-Type") {
-				ae.Headers["Content-Type"] = "application/octet-stream"
+			if !hasHeaderFold(headers, "Content-Type") {
+				headers["Content-Type"] = "application/octet-stream"
 			}
 			// Content-Length is output-only and computed by Cloud Tasks, which
 			// materializes it on the stored AppEngine task.
-			ae.Headers["Content-Length"] = strconv.Itoa(len(ae.Body))
+			headers["Content-Length"] = strconv.Itoa(len(body))
 		}
+		ae.Headers = maybe.Some(headers)
 
 		// Routing is always present on a stored AppEngine task; an absent one
 		// defaults to the zero routing, whose Host is then filled in below.
 		routing := ae.AppEngineRouting.OrZero()
-		if routing.Host == "" {
+		if routing.Host.OrZero() == "" {
 			var host, domainSeparator string
 
 			if appEngineHost == "" {
@@ -200,17 +204,17 @@ func setInitialTaskState(s *TaskState, queueName string, appEngineHost string) {
 				panic(err)
 			}
 
-			if routing.Service != "" {
-				hostURL.Host = routing.Service + domainSeparator + hostURL.Host
+			if svc := routing.Service.OrZero(); svc != "" {
+				hostURL.Host = svc + domainSeparator + hostURL.Host
 			}
-			if routing.Version != "" {
-				hostURL.Host = routing.Version + domainSeparator + hostURL.Host
+			if ver := routing.Version.OrZero(); ver != "" {
+				hostURL.Host = ver + domainSeparator + hostURL.Host
 			}
-			if routing.Instance != "" {
-				hostURL.Host = routing.Instance + domainSeparator + hostURL.Host
+			if inst := routing.Instance.OrZero(); inst != "" {
+				hostURL.Host = inst + domainSeparator + hostURL.Host
 			}
 
-			routing.Host = hostURL.String()
+			routing.Host = maybe.Some(hostURL.String())
 		}
 		ae.AppEngineRouting = maybe.Some(routing)
 

--- a/internal/engine/task.go
+++ b/internal/engine/task.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/aertje/cloud-tasks-emulator/v2/internal/maybe"
 )
 
 var (
@@ -102,9 +104,11 @@ func (task *Task) markDone() {
 
 // State returns a snapshot of the task state.
 //
-// Note: TaskState is a value type but contains pointers (HTTPRequest /
-// AppEngineHTTPRequest / Attempt / Headers map), so the snapshot is shallow.
-// Callers that need a deep copy should round-trip via taskToProto at the edge.
+// Note: TaskState and its Maybe-wrapped members (HTTPRequest /
+// AppEngineHTTPRequest / Attempt) are value types and copy by value, but the
+// Headers map and Body slice they carry are references, so the snapshot is
+// shallow. Callers that need a deep copy should round-trip via taskToProto at
+// the edge.
 func (t *Task) State() TaskState {
 	t.stateMutex.Lock()
 	defer t.stateMutex.Unlock()
@@ -134,31 +138,26 @@ func setInitialTaskState(s *TaskState, queueName string, appEngineHost string) {
 	}
 
 	// Cloud only sets whole-second precision on CreateTime.
-	s.CreateTime = time.Unix(time.Now().Unix(), 0)
+	s.CreateTime = maybe.Some(time.Unix(time.Now().Unix(), 0))
 
-	if s.ScheduleTime.IsZero() {
-		s.ScheduleTime = time.Now()
-	}
-	if s.DispatchDeadline == 0 {
-		s.DispatchDeadline = 600 * time.Second
-	}
+	s.ScheduleTime = s.ScheduleTime.Or(time.Now())
+	s.DispatchDeadline = s.DispatchDeadline.Or(600 * time.Second)
 
-	if s.HTTPRequest != nil {
-		if s.HTTPRequest.Method == "" {
-			s.HTTPRequest.Method = http.MethodPost
-		}
-		if s.HTTPRequest.Headers == nil {
-			s.HTTPRequest.Headers = make(map[string]string)
+	// HTTPRequest / AppEngineHTTPRequest are value-typed Maybes, so their
+	// defaults are applied to a copy pulled out with Get and stored back with
+	// Some rather than mutated in place.
+	if hr, ok := s.HTTPRequest.Get(); ok {
+		hr.Method = hr.Method.Or(http.MethodPost)
+		if hr.Headers == nil {
+			hr.Headers = make(map[string]string)
 		}
 		// Cloud Tasks overrides any caller-supplied User-Agent.
-		s.HTTPRequest.Headers["User-Agent"] = "Google-Cloud-Tasks"
+		hr.Headers["User-Agent"] = "Google-Cloud-Tasks"
+		s.HTTPRequest = maybe.Some(hr)
 	}
 
-	if s.AppEngineHTTPRequest != nil {
-		ae := s.AppEngineHTTPRequest
-		if ae.Method == "" {
-			ae.Method = http.MethodPost
-		}
+	if ae, ok := s.AppEngineHTTPRequest.Get(); ok {
+		ae.Method = ae.Method.Or(http.MethodPost)
 		if ae.Headers == nil {
 			ae.Headers = make(map[string]string)
 		}
@@ -178,11 +177,10 @@ func setInitialTaskState(s *TaskState, queueName string, appEngineHost string) {
 			ae.Headers["Content-Length"] = strconv.Itoa(len(ae.Body))
 		}
 
-		if ae.AppEngineRouting == nil {
-			ae.AppEngineRouting = &AppEngineRouting{}
-		}
-
-		if ae.AppEngineRouting.Host == "" {
+		// Routing is always present on a stored AppEngine task; an absent one
+		// defaults to the zero routing, whose Host is then filled in below.
+		routing := ae.AppEngineRouting.OrZero()
+		if routing.Host == "" {
 			var host, domainSeparator string
 
 			if appEngineHost == "" {
@@ -202,22 +200,22 @@ func setInitialTaskState(s *TaskState, queueName string, appEngineHost string) {
 				panic(err)
 			}
 
-			if ae.AppEngineRouting.Service != "" {
-				hostURL.Host = ae.AppEngineRouting.Service + domainSeparator + hostURL.Host
+			if routing.Service != "" {
+				hostURL.Host = routing.Service + domainSeparator + hostURL.Host
 			}
-			if ae.AppEngineRouting.Version != "" {
-				hostURL.Host = ae.AppEngineRouting.Version + domainSeparator + hostURL.Host
+			if routing.Version != "" {
+				hostURL.Host = routing.Version + domainSeparator + hostURL.Host
 			}
-			if ae.AppEngineRouting.Instance != "" {
-				hostURL.Host = ae.AppEngineRouting.Instance + domainSeparator + hostURL.Host
+			if routing.Instance != "" {
+				hostURL.Host = routing.Instance + domainSeparator + hostURL.Host
 			}
 
-			ae.AppEngineRouting.Host = hostURL.String()
+			routing.Host = hostURL.String()
 		}
+		ae.AppEngineRouting = maybe.Some(routing)
 
-		if ae.RelativeURI == "" {
-			ae.RelativeURI = "/"
-		}
+		ae.RelativeURI = ae.RelativeURI.Or("/")
+		s.AppEngineHTTPRequest = maybe.Some(ae)
 	}
 }
 
@@ -250,7 +248,7 @@ func (task *Task) Delete() {
 // It is initially called by the queue, later by the task reschedule.
 func (task *Task) Schedule() {
 	task.stateMutex.Lock()
-	scheduleTime := task.state.ScheduleTime
+	scheduleTime := task.state.ScheduleTime.OrZero()
 	task.stateMutex.Unlock()
 
 	fromNow := time.Until(scheduleTime)

--- a/internal/engine/task.go
+++ b/internal/engine/task.go
@@ -104,7 +104,7 @@ func (task *Task) markDone() {
 
 // State returns a snapshot of the task state.
 //
-// Note: TaskState and its Maybe-wrapped members (HTTPRequest /
+// Note: TaskState and its maybe.M-wrapped members (HTTPRequest /
 // AppEngineHTTPRequest / Attempt) are value types and copy by value, but the
 // Headers map and Body slice they carry are references, so the snapshot is
 // shallow. Callers that need a deep copy should round-trip via taskToProto at

--- a/internal/engine/task_internal_test.go
+++ b/internal/engine/task_internal_test.go
@@ -3,53 +3,54 @@ package engine
 import (
 	"testing"
 
+	"github.com/aertje/cloud-tasks-emulator/v2/internal/maybe"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSetInitialTaskStateAppEngineNoEmulatorDefaults(t *testing.T) {
 	state := TaskState{
-		AppEngineHTTPRequest: &AppEngineHTTPRequest{},
+		AppEngineHTTPRequest: maybe.Some(AppEngineHTTPRequest{}),
 	}
 	setInitialTaskState(&state, "projects/bluebook/locations/us-east1/queues/agentq", "")
 
-	assert.Equal(t, "https://bluebook.appspot.com", state.AppEngineHTTPRequest.AppEngineRouting.Host)
+	assert.Equal(t, "https://bluebook.appspot.com", state.AppEngineHTTPRequest.OrZero().AppEngineRouting.OrZero().Host)
 }
 
 func TestInitialTaskStateAppEngineNoEmulatorTargeted(t *testing.T) {
 	state := TaskState{
-		AppEngineHTTPRequest: &AppEngineHTTPRequest{
-			AppEngineRouting: &AppEngineRouting{
+		AppEngineHTTPRequest: maybe.Some(AppEngineHTTPRequest{
+			AppEngineRouting: maybe.Some(AppEngineRouting{
 				Service:  "worker",
 				Version:  "v1",
 				Instance: "2",
-			},
-		},
+			}),
+		}),
 	}
 	setInitialTaskState(&state, "projects/bluebook/locations/us-east1/queues/agentq", "")
 
-	assert.Equal(t, "https://2-dot-v1-dot-worker-dot-bluebook.appspot.com", state.AppEngineHTTPRequest.AppEngineRouting.Host)
+	assert.Equal(t, "https://2-dot-v1-dot-worker-dot-bluebook.appspot.com", state.AppEngineHTTPRequest.OrZero().AppEngineRouting.OrZero().Host)
 }
 
 func TestSetInitialTaskStateAppEngineEmulatorDefaults(t *testing.T) {
 	state := TaskState{
-		AppEngineHTTPRequest: &AppEngineHTTPRequest{},
+		AppEngineHTTPRequest: maybe.Some(AppEngineHTTPRequest{}),
 	}
 	setInitialTaskState(&state, "projects/bluebook/locations/us-east1/queues/agentq", "http://localhost:1234")
 
-	assert.Equal(t, "http://localhost:1234", state.AppEngineHTTPRequest.AppEngineRouting.Host)
+	assert.Equal(t, "http://localhost:1234", state.AppEngineHTTPRequest.OrZero().AppEngineRouting.OrZero().Host)
 }
 
 func TestSetInitialTaskStateAppEngineEmulatorTargeted(t *testing.T) {
 	state := TaskState{
-		AppEngineHTTPRequest: &AppEngineHTTPRequest{
-			AppEngineRouting: &AppEngineRouting{
+		AppEngineHTTPRequest: maybe.Some(AppEngineHTTPRequest{
+			AppEngineRouting: maybe.Some(AppEngineRouting{
 				Service:  "worker",
 				Version:  "v1",
 				Instance: "2",
-			},
-		},
+			}),
+		}),
 	}
 	setInitialTaskState(&state, "projects/bluebook/locations/us-east1/queues/agentq", "http://nginx")
 
-	assert.Equal(t, "http://2.v1.worker.nginx", state.AppEngineHTTPRequest.AppEngineRouting.Host)
+	assert.Equal(t, "http://2.v1.worker.nginx", state.AppEngineHTTPRequest.OrZero().AppEngineRouting.OrZero().Host)
 }

--- a/internal/engine/task_internal_test.go
+++ b/internal/engine/task_internal_test.go
@@ -13,22 +13,22 @@ func TestSetInitialTaskStateAppEngineNoEmulatorDefaults(t *testing.T) {
 	}
 	setInitialTaskState(&state, "projects/bluebook/locations/us-east1/queues/agentq", "")
 
-	assert.Equal(t, "https://bluebook.appspot.com", state.AppEngineHTTPRequest.OrZero().AppEngineRouting.OrZero().Host)
+	assert.Equal(t, "https://bluebook.appspot.com", state.AppEngineHTTPRequest.OrZero().AppEngineRouting.OrZero().Host.OrZero())
 }
 
 func TestInitialTaskStateAppEngineNoEmulatorTargeted(t *testing.T) {
 	state := TaskState{
 		AppEngineHTTPRequest: maybe.Some(AppEngineHTTPRequest{
 			AppEngineRouting: maybe.Some(AppEngineRouting{
-				Service:  "worker",
-				Version:  "v1",
-				Instance: "2",
+				Service:  maybe.Some("worker"),
+				Version:  maybe.Some("v1"),
+				Instance: maybe.Some("2"),
 			}),
 		}),
 	}
 	setInitialTaskState(&state, "projects/bluebook/locations/us-east1/queues/agentq", "")
 
-	assert.Equal(t, "https://2-dot-v1-dot-worker-dot-bluebook.appspot.com", state.AppEngineHTTPRequest.OrZero().AppEngineRouting.OrZero().Host)
+	assert.Equal(t, "https://2-dot-v1-dot-worker-dot-bluebook.appspot.com", state.AppEngineHTTPRequest.OrZero().AppEngineRouting.OrZero().Host.OrZero())
 }
 
 func TestSetInitialTaskStateAppEngineEmulatorDefaults(t *testing.T) {
@@ -37,20 +37,20 @@ func TestSetInitialTaskStateAppEngineEmulatorDefaults(t *testing.T) {
 	}
 	setInitialTaskState(&state, "projects/bluebook/locations/us-east1/queues/agentq", "http://localhost:1234")
 
-	assert.Equal(t, "http://localhost:1234", state.AppEngineHTTPRequest.OrZero().AppEngineRouting.OrZero().Host)
+	assert.Equal(t, "http://localhost:1234", state.AppEngineHTTPRequest.OrZero().AppEngineRouting.OrZero().Host.OrZero())
 }
 
 func TestSetInitialTaskStateAppEngineEmulatorTargeted(t *testing.T) {
 	state := TaskState{
 		AppEngineHTTPRequest: maybe.Some(AppEngineHTTPRequest{
 			AppEngineRouting: maybe.Some(AppEngineRouting{
-				Service:  "worker",
-				Version:  "v1",
-				Instance: "2",
+				Service:  maybe.Some("worker"),
+				Version:  maybe.Some("v1"),
+				Instance: maybe.Some("2"),
 			}),
 		}),
 	}
 	setInitialTaskState(&state, "projects/bluebook/locations/us-east1/queues/agentq", "http://nginx")
 
-	assert.Equal(t, "http://2.v1.worker.nginx", state.AppEngineHTTPRequest.OrZero().AppEngineRouting.OrZero().Host)
+	assert.Equal(t, "http://2.v1.worker.nginx", state.AppEngineHTTPRequest.OrZero().AppEngineRouting.OrZero().Host.OrZero())
 }

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -8,7 +8,7 @@ import (
 
 // Optionality convention for the state types below: a field that may be
 // genuinely absent - an unset input still awaiting a server default, or state a
-// task has not reached yet - is a maybe.Maybe[T]. Everything else is always
+// task has not reached yet - is a maybe.M[T]. Everything else is always
 // present and stays plain: counters, resource names, the queue-run enum, an
 // attempt's status code/message, and a token's service-account email.
 
@@ -23,20 +23,20 @@ const (
 )
 
 // RateLimits holds the per-queue dispatch rate configuration. Each field is a
-// Maybe: absent means "apply the server default" (see setInitialQueueState).
+// maybe.M: absent means "apply the server default" (see setInitialQueueState).
 type RateLimits struct {
-	MaxDispatchesPerSecond  maybe.Maybe[float64]
-	MaxBurstSize            maybe.Maybe[int32]
-	MaxConcurrentDispatches maybe.Maybe[int32]
+	MaxDispatchesPerSecond  maybe.M[float64]
+	MaxBurstSize            maybe.M[int32]
+	MaxConcurrentDispatches maybe.M[int32]
 }
 
 // RetryConfig holds the per-queue retry/backoff configuration. Each field is a
-// Maybe: absent means "apply the server default" (see setInitialQueueState).
+// maybe.M: absent means "apply the server default" (see setInitialQueueState).
 type RetryConfig struct {
-	MaxAttempts  maybe.Maybe[int32]
-	MaxDoublings maybe.Maybe[int32]
-	MinBackoff   maybe.Maybe[time.Duration]
-	MaxBackoff   maybe.Maybe[time.Duration]
+	MaxAttempts  maybe.M[int32]
+	MaxDoublings maybe.M[int32]
+	MinBackoff   maybe.M[time.Duration]
+	MaxBackoff   maybe.M[time.Duration]
 }
 
 // QueueState is the engine's view of a queue. Proto<->QueueState mapping
@@ -55,9 +55,9 @@ type TaskState struct {
 	// CreateTime, ScheduleTime and DispatchDeadline are absent on a task-creation
 	// input and filled with server-assigned values by setInitialTaskState, after
 	// which they are always present on a live task.
-	CreateTime       maybe.Maybe[time.Time]
-	ScheduleTime     maybe.Maybe[time.Time]
-	DispatchDeadline maybe.Maybe[time.Duration]
+	CreateTime       maybe.M[time.Time]
+	ScheduleTime     maybe.M[time.Time]
+	DispatchDeadline maybe.M[time.Duration]
 
 	DispatchCount int32
 	// ResponseCount counts attempts that received an HTTP response - a transport
@@ -74,29 +74,29 @@ type TaskState struct {
 	// populated only on the snapshot returned by updateStateForDispatch (absent on
 	// the first attempt, or when the previous attempt received no HTTP response)
 	// and feeds the retry-only X-*-TaskPreviousResponse dispatch header.
-	PreviousResponseCode maybe.Maybe[int]
+	PreviousResponseCode maybe.M[int]
 
-	FirstAttempt maybe.Maybe[Attempt]
-	LastAttempt  maybe.Maybe[Attempt]
+	FirstAttempt maybe.M[Attempt]
+	LastAttempt  maybe.M[Attempt]
 
-	HTTPRequest          maybe.Maybe[HTTPRequest]
-	AppEngineHTTPRequest maybe.Maybe[AppEngineHTTPRequest]
+	HTTPRequest          maybe.M[HTTPRequest]
+	AppEngineHTTPRequest maybe.M[AppEngineHTTPRequest]
 }
 
 // Attempt records a single dispatch attempt against a task target. The response
 // fields (ResponseTime, ResponseStatus, ResponseCode) are absent until the
 // attempt has completed.
 type Attempt struct {
-	ScheduleTime   maybe.Maybe[time.Time]
-	DispatchTime   maybe.Maybe[time.Time]
-	ResponseTime   maybe.Maybe[time.Time]
-	ResponseStatus maybe.Maybe[AttemptStatus]
+	ScheduleTime   maybe.M[time.Time]
+	DispatchTime   maybe.M[time.Time]
+	ResponseTime   maybe.M[time.Time]
+	ResponseStatus maybe.M[AttemptStatus]
 	// ResponseCode is the raw HTTP status the target returned for this attempt
 	// (e.g. 503), or a negative marker when no HTTP response was received
 	// (transport failure). It is absent until the attempt completes. It is kept
 	// alongside the RPC-coded ResponseStatus so the next dispatch can report it
 	// via X-*-TaskPreviousResponse.
-	ResponseCode maybe.Maybe[int]
+	ResponseCode maybe.M[int]
 }
 
 // AttemptStatus is the gRPC-style status of a dispatch attempt.
@@ -111,37 +111,37 @@ type AttemptStatus struct {
 // to POST at creation. URL is absent only on an unvalidated creation input; a
 // live task always carries one.
 type HTTPRequest struct {
-	URL       maybe.Maybe[string]
-	Method    maybe.Maybe[string]
-	Headers   maybe.Maybe[map[string]string]
-	Body      maybe.Maybe[[]byte]
-	OIDCToken maybe.Maybe[OIDCToken]
+	URL       maybe.M[string]
+	Method    maybe.M[string]
+	Headers   maybe.M[map[string]string]
+	Body      maybe.M[[]byte]
+	OIDCToken maybe.M[OIDCToken]
 }
 
 // OIDCToken describes the OIDC credentials to mint for the HTTP target. Audience
 // is absent when the caller left it to default to the target URL.
 type OIDCToken struct {
 	ServiceAccountEmail string
-	Audience            maybe.Maybe[string]
+	Audience            maybe.M[string]
 }
 
 // AppEngineHTTPRequest is the engine view of an App Engine target. Method
 // (absent defaults to POST) and RelativeURI (absent defaults to "/") are filled
 // in at creation.
 type AppEngineHTTPRequest struct {
-	Method           maybe.Maybe[string]
-	AppEngineRouting maybe.Maybe[AppEngineRouting]
-	RelativeURI      maybe.Maybe[string]
-	Headers          maybe.Maybe[map[string]string]
-	Body             maybe.Maybe[[]byte]
+	Method           maybe.M[string]
+	AppEngineRouting maybe.M[AppEngineRouting]
+	RelativeURI      maybe.M[string]
+	Headers          maybe.M[map[string]string]
+	Body             maybe.M[[]byte]
 }
 
 // AppEngineRouting describes the App Engine service routing for a request. Each
 // field is absent when the caller left it to the App Engine default; Host is
 // absent on input and filled in at creation.
 type AppEngineRouting struct {
-	Service  maybe.Maybe[string]
-	Version  maybe.Maybe[string]
-	Instance maybe.Maybe[string]
-	Host     maybe.Maybe[string]
+	Service  maybe.M[string]
+	Version  maybe.M[string]
+	Instance maybe.M[string]
+	Host     maybe.M[string]
 }

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -6,13 +6,11 @@ import (
 	"github.com/aertje/cloud-tasks-emulator/v2/internal/maybe"
 )
 
-// Optionality convention for the state types below: a maybe.Maybe[T] marks a
-// value that may be genuinely absent - an unset input still awaiting a
-// server-assigned default, or state a task has not reached yet (e.g. the
-// response of an attempt still in flight). Values that always carry a meaning
-// within a present parent stay plain: counters, names, the queue-run enum, and
-// the request scalars whose empty value already reads as "unset" and are
-// defaulted at creation (Method, URL, RelativeURI, Headers, Body).
+// Optionality convention for the state types below: a field that may be
+// genuinely absent - an unset input still awaiting a server default, or state a
+// task has not reached yet - is a maybe.Maybe[T]. Everything else is always
+// present and stays plain: counters, resource names, the queue-run enum, an
+// attempt's status code/message, and a token's service-account email.
 
 // QueueRunState mirrors tasks.Queue_State but lives in the engine layer.
 type QueueRunState int
@@ -110,19 +108,21 @@ type AttemptStatus struct {
 
 // HTTPRequest is the engine view of a Cloud Tasks HTTP target. Method is the
 // uppercase HTTP verb (e.g. "POST"); absent means unspecified and is defaulted
-// to POST at creation.
+// to POST at creation. URL is absent only on an unvalidated creation input; a
+// live task always carries one.
 type HTTPRequest struct {
-	URL       string
+	URL       maybe.Maybe[string]
 	Method    maybe.Maybe[string]
-	Headers   map[string]string
-	Body      []byte
+	Headers   maybe.Maybe[map[string]string]
+	Body      maybe.Maybe[[]byte]
 	OIDCToken maybe.Maybe[OIDCToken]
 }
 
-// OIDCToken describes the OIDC credentials to mint for the HTTP target.
+// OIDCToken describes the OIDC credentials to mint for the HTTP target. Audience
+// is absent when the caller left it to default to the target URL.
 type OIDCToken struct {
 	ServiceAccountEmail string
-	Audience            string
+	Audience            maybe.Maybe[string]
 }
 
 // AppEngineHTTPRequest is the engine view of an App Engine target. Method
@@ -132,14 +132,16 @@ type AppEngineHTTPRequest struct {
 	Method           maybe.Maybe[string]
 	AppEngineRouting maybe.Maybe[AppEngineRouting]
 	RelativeURI      maybe.Maybe[string]
-	Headers          map[string]string
-	Body             []byte
+	Headers          maybe.Maybe[map[string]string]
+	Body             maybe.Maybe[[]byte]
 }
 
-// AppEngineRouting describes the App Engine service routing for a request.
+// AppEngineRouting describes the App Engine service routing for a request. Each
+// field is absent when the caller left it to the App Engine default; Host is
+// absent on input and filled in at creation.
 type AppEngineRouting struct {
-	Service  string
-	Version  string
-	Instance string
-	Host     string
+	Service  maybe.Maybe[string]
+	Version  maybe.Maybe[string]
+	Instance maybe.Maybe[string]
+	Host     maybe.Maybe[string]
 }

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -1,6 +1,18 @@
 package engine
 
-import "time"
+import (
+	"time"
+
+	"github.com/aertje/cloud-tasks-emulator/v2/internal/maybe"
+)
+
+// Optionality convention for the state types below: a maybe.Maybe[T] marks a
+// value that may be genuinely absent - an unset input still awaiting a
+// server-assigned default, or state a task has not reached yet (e.g. the
+// response of an attempt still in flight). Values that always carry a meaning
+// within a present parent stay plain: counters, names, the queue-run enum, and
+// the request scalars whose empty value already reads as "unset" and are
+// defaulted at creation (Method, URL, RelativeURI, Headers, Body).
 
 // QueueRunState mirrors tasks.Queue_State but lives in the engine layer.
 type QueueRunState int
@@ -12,19 +24,21 @@ const (
 	QueueRunStateDisabled
 )
 
-// RateLimits holds the per-queue dispatch rate configuration.
+// RateLimits holds the per-queue dispatch rate configuration. Each field is a
+// Maybe: absent means "apply the server default" (see setInitialQueueState).
 type RateLimits struct {
-	MaxDispatchesPerSecond  float64
-	MaxBurstSize            int32
-	MaxConcurrentDispatches int32
+	MaxDispatchesPerSecond  maybe.Maybe[float64]
+	MaxBurstSize            maybe.Maybe[int32]
+	MaxConcurrentDispatches maybe.Maybe[int32]
 }
 
-// RetryConfig holds the per-queue retry/backoff configuration.
+// RetryConfig holds the per-queue retry/backoff configuration. Each field is a
+// Maybe: absent means "apply the server default" (see setInitialQueueState).
 type RetryConfig struct {
-	MaxAttempts  int32
-	MaxDoublings int32
-	MinBackoff   time.Duration
-	MaxBackoff   time.Duration
+	MaxAttempts  maybe.Maybe[int32]
+	MaxDoublings maybe.Maybe[int32]
+	MinBackoff   maybe.Maybe[time.Duration]
+	MaxBackoff   maybe.Maybe[time.Duration]
 }
 
 // QueueState is the engine's view of a queue. Proto<->QueueState mapping
@@ -37,12 +51,15 @@ type QueueState struct {
 }
 
 // TaskState is the engine's view of a task. Exactly one of HTTPRequest /
-// AppEngineHTTPRequest is non-nil for any live task.
+// AppEngineHTTPRequest is present for any live task.
 type TaskState struct {
-	Name             string
-	CreateTime       time.Time
-	ScheduleTime     time.Time
-	DispatchDeadline time.Duration
+	Name string
+	// CreateTime, ScheduleTime and DispatchDeadline are absent on a task-creation
+	// input and filled with server-assigned values by setInitialTaskState, after
+	// which they are always present on a live task.
+	CreateTime       maybe.Maybe[time.Time]
+	ScheduleTime     maybe.Maybe[time.Time]
+	DispatchDeadline maybe.Maybe[time.Duration]
 
 	DispatchCount int32
 	// ResponseCount counts attempts that received an HTTP response - a transport
@@ -56,29 +73,32 @@ type TaskState struct {
 	ExecutionCount int32
 
 	// PreviousResponseCode is the raw HTTP status of the previous attempt. It is
-	// populated only on the snapshot returned by updateStateForDispatch (0 on the
-	// first attempt, or when the previous attempt received no HTTP response) and
-	// feeds the retry-only X-*-TaskPreviousResponse dispatch header.
-	PreviousResponseCode int
+	// populated only on the snapshot returned by updateStateForDispatch (absent on
+	// the first attempt, or when the previous attempt received no HTTP response)
+	// and feeds the retry-only X-*-TaskPreviousResponse dispatch header.
+	PreviousResponseCode maybe.Maybe[int]
 
-	FirstAttempt *Attempt
-	LastAttempt  *Attempt
+	FirstAttempt maybe.Maybe[Attempt]
+	LastAttempt  maybe.Maybe[Attempt]
 
-	HTTPRequest          *HTTPRequest
-	AppEngineHTTPRequest *AppEngineHTTPRequest
+	HTTPRequest          maybe.Maybe[HTTPRequest]
+	AppEngineHTTPRequest maybe.Maybe[AppEngineHTTPRequest]
 }
 
-// Attempt records a single dispatch attempt against a task target.
+// Attempt records a single dispatch attempt against a task target. The response
+// fields (ResponseTime, ResponseStatus, ResponseCode) are absent until the
+// attempt has completed.
 type Attempt struct {
-	ScheduleTime   time.Time
-	DispatchTime   time.Time
-	ResponseTime   time.Time
-	ResponseStatus *AttemptStatus
+	ScheduleTime   maybe.Maybe[time.Time]
+	DispatchTime   maybe.Maybe[time.Time]
+	ResponseTime   maybe.Maybe[time.Time]
+	ResponseStatus maybe.Maybe[AttemptStatus]
 	// ResponseCode is the raw HTTP status the target returned for this attempt
-	// (e.g. 503), or 0 when no HTTP response was received (transport failure). It
-	// is kept alongside the RPC-coded ResponseStatus so the next dispatch can
-	// report it via X-*-TaskPreviousResponse.
-	ResponseCode int
+	// (e.g. 503), or a negative marker when no HTTP response was received
+	// (transport failure). It is absent until the attempt completes. It is kept
+	// alongside the RPC-coded ResponseStatus so the next dispatch can report it
+	// via X-*-TaskPreviousResponse.
+	ResponseCode maybe.Maybe[int]
 }
 
 // AttemptStatus is the gRPC-style status of a dispatch attempt.
@@ -88,14 +108,15 @@ type AttemptStatus struct {
 	Message string
 }
 
-// HTTPRequest is the engine view of a Cloud Tasks HTTP target.
-// Method is the uppercase HTTP verb (e.g. "POST"); empty means unspecified.
+// HTTPRequest is the engine view of a Cloud Tasks HTTP target. Method is the
+// uppercase HTTP verb (e.g. "POST"); absent means unspecified and is defaulted
+// to POST at creation.
 type HTTPRequest struct {
 	URL       string
-	Method    string
+	Method    maybe.Maybe[string]
 	Headers   map[string]string
 	Body      []byte
-	OIDCToken *OIDCToken
+	OIDCToken maybe.Maybe[OIDCToken]
 }
 
 // OIDCToken describes the OIDC credentials to mint for the HTTP target.
@@ -104,11 +125,13 @@ type OIDCToken struct {
 	Audience            string
 }
 
-// AppEngineHTTPRequest is the engine view of an App Engine target.
+// AppEngineHTTPRequest is the engine view of an App Engine target. Method
+// (absent defaults to POST) and RelativeURI (absent defaults to "/") are filled
+// in at creation.
 type AppEngineHTTPRequest struct {
-	Method           string
-	AppEngineRouting *AppEngineRouting
-	RelativeURI      string
+	Method           maybe.Maybe[string]
+	AppEngineRouting maybe.Maybe[AppEngineRouting]
+	RelativeURI      maybe.Maybe[string]
 	Headers          map[string]string
 	Body             []byte
 }

--- a/internal/engine/worker_pool_internal_test.go
+++ b/internal/engine/worker_pool_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aertje/cloud-tasks-emulator/v2/internal/maybe"
 	"github.com/aertje/cloud-tasks-emulator/v2/internal/oidc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,7 +71,7 @@ func TestDispatchConcurrencyIsBounded(t *testing.T) {
 		Name: testParent,
 		// A generous rate limit so the token bucket, a separate axis, does not
 		// throttle the backlog and mask the concurrency bound under test.
-		RateLimits: RateLimits{MaxConcurrentDispatches: maxConcurrent, MaxBurstSize: 100, MaxDispatchesPerSecond: 1000},
+		RateLimits: RateLimits{MaxConcurrentDispatches: maybe.Some[int32](maxConcurrent), MaxBurstSize: maybe.Some[int32](100), MaxDispatchesPerSecond: maybe.Some[float64](1000)},
 	})
 	require.NoError(t, err)
 

--- a/internal/maybe/maybe.go
+++ b/internal/maybe/maybe.go
@@ -1,29 +1,29 @@
-// Package maybe provides Maybe, a generic optional value that makes the
+// Package maybe provides M, a generic optional value that makes the
 // presence or absence of a value explicit rather than overloading a nil
 // pointer to mean "absent".
 package maybe
 
-// Maybe holds a value that may or may not be present. The zero value is an
-// absent Maybe, equivalent to None. When T is comparable, Maybe[T] is
+// M holds a value that may or may not be present. The zero value is an
+// absent M, equivalent to None. When T is comparable, M[T] is
 // comparable too.
-type Maybe[T any] struct {
+type M[T any] struct {
 	value   T
 	present bool
 }
 
-// Some returns a Maybe containing v.
-func Some[T any](v T) Maybe[T] {
-	return Maybe[T]{value: v, present: true}
+// Some returns an M containing v.
+func Some[T any](v T) M[T] {
+	return M[T]{value: v, present: true}
 }
 
-// None returns an absent Maybe of type T.
-func None[T any]() Maybe[T] {
-	return Maybe[T]{}
+// None returns an absent M of type T.
+func None[T any]() M[T] {
+	return M[T]{}
 }
 
 // OfPtr returns Some(*p) when p is non-nil and None otherwise. It bridges
-// pointer-based APIs (such as generated protobuf types) into a Maybe.
-func OfPtr[T any](p *T) Maybe[T] {
+// pointer-based APIs (such as generated protobuf types) into an M.
+func OfPtr[T any](p *T) M[T] {
 	if p == nil {
 		return None[T]()
 	}
@@ -32,8 +32,8 @@ func OfPtr[T any](p *T) Maybe[T] {
 
 // OfNonZero returns Some(v) unless v is the zero value of T, in which case it
 // returns None. It bridges APIs that overload a zero value to mean "absent"
-// (such as proto3 scalar fields) into a Maybe.
-func OfNonZero[T comparable](v T) Maybe[T] {
+// (such as proto3 scalar fields) into an M.
+func OfNonZero[T comparable](v T) M[T] {
 	var zero T
 	if v == zero {
 		return None[T]()
@@ -42,18 +42,18 @@ func OfNonZero[T comparable](v T) Maybe[T] {
 }
 
 // IsPresent reports whether a value is present.
-func (m Maybe[T]) IsPresent() bool {
+func (m M[T]) IsPresent() bool {
 	return m.present
 }
 
 // Get returns the contained value and whether it was present. When absent the
 // returned value is the zero value of T.
-func (m Maybe[T]) Get() (T, bool) {
+func (m M[T]) Get() (T, bool) {
 	return m.value, m.present
 }
 
 // OrElse returns the contained value if present, otherwise def.
-func (m Maybe[T]) OrElse(def T) T {
+func (m M[T]) OrElse(def T) T {
 	if m.present {
 		return m.value
 	}
@@ -63,7 +63,7 @@ func (m Maybe[T]) OrElse(def T) T {
 // Or returns m if it is present, otherwise Some(def). Unlike OrElse it keeps the
 // result wrapped, so it reads as "fill in a default when absent" (e.g. applying
 // a server-assigned default to an optional field).
-func (m Maybe[T]) Or(def T) Maybe[T] {
+func (m M[T]) Or(def T) M[T] {
 	if m.present {
 		return m
 	}
@@ -71,13 +71,13 @@ func (m Maybe[T]) Or(def T) Maybe[T] {
 }
 
 // OrZero returns the contained value if present, otherwise the zero value of T.
-func (m Maybe[T]) OrZero() T {
+func (m M[T]) OrZero() T {
 	return m.value
 }
 
 // Ptr returns a pointer to a copy of the contained value, or nil when absent.
-// It bridges a Maybe back into pointer-based APIs.
-func (m Maybe[T]) Ptr() *T {
+// It bridges an M back into pointer-based APIs.
+func (m M[T]) Ptr() *T {
 	if !m.present {
 		return nil
 	}
@@ -85,9 +85,9 @@ func (m Maybe[T]) Ptr() *T {
 	return &v
 }
 
-// Map applies f to the value inside m when present and returns a Maybe of the
+// Map applies f to the value inside m when present and returns an M of the
 // result; when m is absent it returns None.
-func Map[T, U any](m Maybe[T], f func(T) U) Maybe[U] {
+func Map[T, U any](m M[T], f func(T) U) M[U] {
 	v, ok := m.Get()
 	if !ok {
 		return None[U]()

--- a/internal/maybe/maybe.go
+++ b/internal/maybe/maybe.go
@@ -30,6 +30,17 @@ func OfPtr[T any](p *T) Maybe[T] {
 	return Some(*p)
 }
 
+// OfNonZero returns Some(v) unless v is the zero value of T, in which case it
+// returns None. It bridges APIs that overload a zero value to mean "absent"
+// (such as proto3 scalar fields) into a Maybe.
+func OfNonZero[T comparable](v T) Maybe[T] {
+	var zero T
+	if v == zero {
+		return None[T]()
+	}
+	return Some(v)
+}
+
 // IsPresent reports whether a value is present.
 func (m Maybe[T]) IsPresent() bool {
 	return m.present
@@ -47,6 +58,16 @@ func (m Maybe[T]) OrElse(def T) T {
 		return m.value
 	}
 	return def
+}
+
+// Or returns m if it is present, otherwise Some(def). Unlike OrElse it keeps the
+// result wrapped, so it reads as "fill in a default when absent" (e.g. applying
+// a server-assigned default to an optional field).
+func (m Maybe[T]) Or(def T) Maybe[T] {
+	if m.present {
+		return m
+	}
+	return Some(def)
 }
 
 // OrZero returns the contained value if present, otherwise the zero value of T.

--- a/internal/maybe/maybe_test.go
+++ b/internal/maybe/maybe_test.go
@@ -27,7 +27,7 @@ func TestNoneAbsent(t *testing.T) {
 }
 
 func TestZeroValueIsNone(t *testing.T) {
-	var m Maybe[string]
+	var m M[string]
 
 	assert.False(t, m.IsPresent())
 	assert.Equal(t, None[string](), m)
@@ -62,7 +62,7 @@ func TestPtrReturnsCopy(t *testing.T) {
 	p := m.Ptr()
 	*p = 100
 
-	// Mutating the returned pointer must not affect the Maybe.
+	// Mutating the returned pointer must not affect the M.
 	assert.Equal(t, 3, m.OrZero())
 }
 

--- a/internal/maybe/maybe_test.go
+++ b/internal/maybe/maybe_test.go
@@ -76,6 +76,20 @@ func TestOrZero(t *testing.T) {
 	assert.Equal(t, 0, None[int]().OrZero())
 }
 
+func TestOfNonZero(t *testing.T) {
+	assert.Equal(t, Some(5), OfNonZero(5))
+	assert.Equal(t, None[int](), OfNonZero(0))
+	assert.Equal(t, Some("x"), OfNonZero("x"))
+	assert.Equal(t, None[string](), OfNonZero(""))
+}
+
+func TestOr(t *testing.T) {
+	assert.Equal(t, Some(5), Some(5).Or(99))
+	assert.Equal(t, Some(99), None[int]().Or(99))
+	// A present zero value is kept, not replaced by the default.
+	assert.Equal(t, Some(0), Some(0).Or(99))
+}
+
 func TestMap(t *testing.T) {
 	double := func(n int) int { return n * 2 }
 	assert.Equal(t, Some(10), Map(Some(5), double))

--- a/internal/server/protohelpers.go
+++ b/internal/server/protohelpers.go
@@ -277,7 +277,7 @@ func timestampToProto(t time.Time) *timestamppb.Timestamp {
 // absent repeated/bytes field from an explicitly empty one (both decode to a
 // nil getter result), so an empty value maps to None and round-trips back to an
 // absent proto field.
-func someIfNonNil[T []byte | map[string]string](v T) maybe.Maybe[T] {
+func someIfNonNil[T []byte | map[string]string](v T) maybe.M[T] {
 	if v == nil {
 		return maybe.None[T]()
 	}

--- a/internal/server/protohelpers.go
+++ b/internal/server/protohelpers.go
@@ -120,15 +120,15 @@ func taskFromProto(t *tasks.Task) engine.TaskState {
 	}
 	if hr := t.GetHttpRequest(); hr != nil {
 		req := engine.HTTPRequest{
-			URL:     hr.GetUrl(),
+			URL:     maybe.OfNonZero(hr.GetUrl()),
 			Method:  maybe.OfNonZero(httpMethodFromProto(hr.GetHttpMethod())),
-			Headers: copyHeaders(hr.GetHeaders()),
-			Body:    hr.GetBody(),
+			Headers: someIfNonNil(copyHeaders(hr.GetHeaders())),
+			Body:    someIfNonNil(hr.GetBody()),
 		}
 		if ot := hr.GetOidcToken(); ot != nil {
 			req.OIDCToken = maybe.Some(engine.OIDCToken{
 				ServiceAccountEmail: ot.GetServiceAccountEmail(),
-				Audience:            ot.GetAudience(),
+				Audience:            maybe.OfNonZero(ot.GetAudience()),
 			})
 		}
 		s.HTTPRequest = maybe.Some(req)
@@ -137,15 +137,15 @@ func taskFromProto(t *tasks.Task) engine.TaskState {
 		req := engine.AppEngineHTTPRequest{
 			Method:      maybe.OfNonZero(httpMethodFromProto(ae.GetHttpMethod())),
 			RelativeURI: maybe.OfNonZero(ae.GetRelativeUri()),
-			Headers:     copyHeaders(ae.GetHeaders()),
-			Body:        ae.GetBody(),
+			Headers:     someIfNonNil(copyHeaders(ae.GetHeaders())),
+			Body:        someIfNonNil(ae.GetBody()),
 		}
 		if r := ae.GetAppEngineRouting(); r != nil {
 			req.AppEngineRouting = maybe.Some(engine.AppEngineRouting{
-				Service:  r.GetService(),
-				Version:  r.GetVersion(),
-				Instance: r.GetInstance(),
-				Host:     r.GetHost(),
+				Service:  maybe.OfNonZero(r.GetService()),
+				Version:  maybe.OfNonZero(r.GetVersion()),
+				Instance: maybe.OfNonZero(r.GetInstance()),
+				Host:     maybe.OfNonZero(r.GetHost()),
 			})
 		}
 		s.AppEngineHTTPRequest = maybe.Some(req)
@@ -191,16 +191,16 @@ func taskToProto(s engine.TaskState, view tasks.Task_View) *tasks.Task {
 	}
 	if hr, ok := s.HTTPRequest.Get(); ok {
 		req := &tasks.HttpRequest{
-			Url:        hr.URL,
+			Url:        hr.URL.OrZero(),
 			HttpMethod: httpMethodToProto(hr.Method.OrZero()),
-			Headers:    copyHeaders(hr.Headers),
-			Body:       hr.Body,
+			Headers:    copyHeaders(hr.Headers.OrZero()),
+			Body:       hr.Body.OrZero(),
 		}
 		if auth, ok := hr.OIDCToken.Get(); ok {
 			req.AuthorizationHeader = &tasks.HttpRequest_OidcToken{
 				OidcToken: &tasks.OidcToken{
 					ServiceAccountEmail: auth.ServiceAccountEmail,
-					Audience:            auth.Audience,
+					Audience:            auth.Audience.OrZero(),
 				},
 			}
 		}
@@ -212,18 +212,18 @@ func taskToProto(s engine.TaskState, view tasks.Task_View) *tasks.Task {
 		req := &tasks.AppEngineHttpRequest{
 			HttpMethod:  httpMethodToProto(ae.Method.OrZero()),
 			RelativeUri: ae.RelativeURI.OrZero(),
-			Headers:     copyHeaders(ae.Headers),
-			Body:        ae.Body,
+			Headers:     copyHeaders(ae.Headers.OrZero()),
+			Body:        ae.Body.OrZero(),
 		}
 		if view != tasks.Task_FULL {
 			req.Body = nil
 		}
 		if r, ok := ae.AppEngineRouting.Get(); ok {
 			req.AppEngineRouting = &tasks.AppEngineRouting{
-				Service:  r.Service,
-				Version:  r.Version,
-				Instance: r.Instance,
-				Host:     r.Host,
+				Service:  r.Service.OrZero(),
+				Version:  r.Version.OrZero(),
+				Instance: r.Instance.OrZero(),
+				Host:     r.Host.OrZero(),
 			}
 		}
 		t.MessageType = &tasks.Task_AppEngineHttpRequest{AppEngineHttpRequest: req}
@@ -270,6 +270,18 @@ func attemptToProto(a engine.Attempt) *tasks.Attempt {
 
 func timestampToProto(t time.Time) *timestamppb.Timestamp {
 	return timestamppb.New(t)
+}
+
+// someIfNonNil wraps a nilable reference field pulled from a proto: a nil
+// map/slice becomes None, anything else Some. Proto3 cannot distinguish an
+// absent repeated/bytes field from an explicitly empty one (both decode to a
+// nil getter result), so an empty value maps to None and round-trips back to an
+// absent proto field.
+func someIfNonNil[T []byte | map[string]string](v T) maybe.Maybe[T] {
+	if v == nil {
+		return maybe.None[T]()
+	}
+	return maybe.Some(v)
 }
 
 func copyHeaders(in map[string]string) map[string]string {

--- a/internal/server/protohelpers.go
+++ b/internal/server/protohelpers.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aertje/cloud-tasks-emulator/v2/internal/engine"
+	"github.com/aertje/cloud-tasks-emulator/v2/internal/maybe"
 
 	tasks "cloud.google.com/go/cloudtasks/apiv2/cloudtaskspb"
 	errdetails "google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -29,21 +30,20 @@ func queueFromProto(q *tasks.Queue) engine.QueueState {
 	}
 	if rl := q.GetRateLimits(); rl != nil {
 		s.RateLimits = engine.RateLimits{
-			MaxDispatchesPerSecond:  rl.GetMaxDispatchesPerSecond(),
-			MaxBurstSize:            rl.GetMaxBurstSize(),
-			MaxConcurrentDispatches: rl.GetMaxConcurrentDispatches(),
+			MaxDispatchesPerSecond:  maybe.OfNonZero(rl.GetMaxDispatchesPerSecond()),
+			MaxBurstSize:            maybe.OfNonZero(rl.GetMaxBurstSize()),
+			MaxConcurrentDispatches: maybe.OfNonZero(rl.GetMaxConcurrentDispatches()),
 		}
 	}
 	if rc := q.GetRetryConfig(); rc != nil {
 		s.RetryConfig = engine.RetryConfig{
-			MaxAttempts:  rc.GetMaxAttempts(),
-			MaxDoublings: rc.GetMaxDoublings(),
-		}
-		if rc.GetMinBackoff() != nil {
-			s.RetryConfig.MinBackoff = rc.GetMinBackoff().AsDuration()
-		}
-		if rc.GetMaxBackoff() != nil {
-			s.RetryConfig.MaxBackoff = rc.GetMaxBackoff().AsDuration()
+			MaxAttempts:  maybe.OfNonZero(rc.GetMaxAttempts()),
+			MaxDoublings: maybe.OfNonZero(rc.GetMaxDoublings()),
+			// GetMinBackoff/GetMaxBackoff and AsDuration are nil-safe, yielding a
+			// zero duration when the field is absent; a zero backoff is treated as
+			// "unset, apply the server default" (see setInitialQueueState).
+			MinBackoff: maybe.OfNonZero(rc.GetMinBackoff().AsDuration()),
+			MaxBackoff: maybe.OfNonZero(rc.GetMaxBackoff().AsDuration()),
 		}
 	}
 	return s
@@ -54,15 +54,15 @@ func queueToProto(s engine.QueueState) *tasks.Queue {
 		Name:  s.Name,
 		State: queueRunStateToProto(s.State),
 		RateLimits: &tasks.RateLimits{
-			MaxDispatchesPerSecond:  s.RateLimits.MaxDispatchesPerSecond,
-			MaxBurstSize:            s.RateLimits.MaxBurstSize,
-			MaxConcurrentDispatches: s.RateLimits.MaxConcurrentDispatches,
+			MaxDispatchesPerSecond:  s.RateLimits.MaxDispatchesPerSecond.OrZero(),
+			MaxBurstSize:            s.RateLimits.MaxBurstSize.OrZero(),
+			MaxConcurrentDispatches: s.RateLimits.MaxConcurrentDispatches.OrZero(),
 		},
 		RetryConfig: &tasks.RetryConfig{
-			MaxAttempts:  s.RetryConfig.MaxAttempts,
-			MaxDoublings: s.RetryConfig.MaxDoublings,
-			MinBackoff:   durationpb.New(s.RetryConfig.MinBackoff),
-			MaxBackoff:   durationpb.New(s.RetryConfig.MaxBackoff),
+			MaxAttempts:  s.RetryConfig.MaxAttempts.OrZero(),
+			MaxDoublings: s.RetryConfig.MaxDoublings.OrZero(),
+			MinBackoff:   durationpb.New(s.RetryConfig.MinBackoff.OrZero()),
+			MaxBackoff:   durationpb.New(s.RetryConfig.MaxBackoff.OrZero()),
 		},
 	}
 }
@@ -103,49 +103,52 @@ func taskFromProto(t *tasks.Task) engine.TaskState {
 		ResponseCount: t.GetResponseCount(),
 	}
 	if ct := t.GetCreateTime(); ct != nil {
-		s.CreateTime = ct.AsTime()
+		s.CreateTime = maybe.Some(ct.AsTime())
 	}
 	if st := t.GetScheduleTime(); st != nil {
-		s.ScheduleTime = st.AsTime()
+		s.ScheduleTime = maybe.Some(st.AsTime())
 	}
-	if dd := t.GetDispatchDeadline(); dd != nil {
-		s.DispatchDeadline = dd.AsDuration()
-	}
+	// GetDispatchDeadline and AsDuration are nil-safe, yielding a zero duration
+	// when absent; a zero deadline is treated as "unset, apply the server
+	// default" (see setInitialTaskState) rather than a zero (no-timeout) client.
+	s.DispatchDeadline = maybe.OfNonZero(t.GetDispatchDeadline().AsDuration())
 	if fa := t.GetFirstAttempt(); fa != nil {
-		s.FirstAttempt = attemptFromProto(fa)
+		s.FirstAttempt = maybe.Some(attemptFromProto(fa))
 	}
 	if la := t.GetLastAttempt(); la != nil {
-		s.LastAttempt = attemptFromProto(la)
+		s.LastAttempt = maybe.Some(attemptFromProto(la))
 	}
 	if hr := t.GetHttpRequest(); hr != nil {
-		s.HTTPRequest = &engine.HTTPRequest{
+		req := engine.HTTPRequest{
 			URL:     hr.GetUrl(),
-			Method:  httpMethodFromProto(hr.GetHttpMethod()),
+			Method:  maybe.OfNonZero(httpMethodFromProto(hr.GetHttpMethod())),
 			Headers: copyHeaders(hr.GetHeaders()),
 			Body:    hr.GetBody(),
 		}
 		if ot := hr.GetOidcToken(); ot != nil {
-			s.HTTPRequest.OIDCToken = &engine.OIDCToken{
+			req.OIDCToken = maybe.Some(engine.OIDCToken{
 				ServiceAccountEmail: ot.GetServiceAccountEmail(),
 				Audience:            ot.GetAudience(),
-			}
+			})
 		}
+		s.HTTPRequest = maybe.Some(req)
 	}
 	if ae := t.GetAppEngineHttpRequest(); ae != nil {
-		s.AppEngineHTTPRequest = &engine.AppEngineHTTPRequest{
-			Method:      httpMethodFromProto(ae.GetHttpMethod()),
-			RelativeURI: ae.GetRelativeUri(),
+		req := engine.AppEngineHTTPRequest{
+			Method:      maybe.OfNonZero(httpMethodFromProto(ae.GetHttpMethod())),
+			RelativeURI: maybe.OfNonZero(ae.GetRelativeUri()),
 			Headers:     copyHeaders(ae.GetHeaders()),
 			Body:        ae.GetBody(),
 		}
 		if r := ae.GetAppEngineRouting(); r != nil {
-			s.AppEngineHTTPRequest.AppEngineRouting = &engine.AppEngineRouting{
+			req.AppEngineRouting = maybe.Some(engine.AppEngineRouting{
 				Service:  r.GetService(),
 				Version:  r.GetVersion(),
 				Instance: r.GetInstance(),
 				Host:     r.GetHost(),
-			}
+			})
 		}
+		s.AppEngineHTTPRequest = maybe.Some(req)
 	}
 	return s
 }
@@ -171,95 +174,95 @@ func taskToProto(s engine.TaskState, view tasks.Task_View) *tasks.Task {
 		ResponseCount: s.ResponseCount,
 		View:          view,
 	}
-	if !s.CreateTime.IsZero() {
-		t.CreateTime = timestampToProto(s.CreateTime)
+	if ct, ok := s.CreateTime.Get(); ok {
+		t.CreateTime = timestampToProto(ct)
 	}
-	if !s.ScheduleTime.IsZero() {
-		t.ScheduleTime = timestampToProto(s.ScheduleTime)
+	if st, ok := s.ScheduleTime.Get(); ok {
+		t.ScheduleTime = timestampToProto(st)
 	}
-	if s.DispatchDeadline != 0 {
-		t.DispatchDeadline = durationpb.New(s.DispatchDeadline)
+	if dd, ok := s.DispatchDeadline.Get(); ok {
+		t.DispatchDeadline = durationpb.New(dd)
 	}
-	if s.FirstAttempt != nil {
-		t.FirstAttempt = attemptToProto(s.FirstAttempt)
+	if fa, ok := s.FirstAttempt.Get(); ok {
+		t.FirstAttempt = attemptToProto(fa)
 	}
-	if s.LastAttempt != nil {
-		t.LastAttempt = attemptToProto(s.LastAttempt)
+	if la, ok := s.LastAttempt.Get(); ok {
+		t.LastAttempt = attemptToProto(la)
 	}
-	if s.HTTPRequest != nil {
-		hr := &tasks.HttpRequest{
-			Url:        s.HTTPRequest.URL,
-			HttpMethod: httpMethodToProto(s.HTTPRequest.Method),
-			Headers:    copyHeaders(s.HTTPRequest.Headers),
-			Body:       s.HTTPRequest.Body,
+	if hr, ok := s.HTTPRequest.Get(); ok {
+		req := &tasks.HttpRequest{
+			Url:        hr.URL,
+			HttpMethod: httpMethodToProto(hr.Method.OrZero()),
+			Headers:    copyHeaders(hr.Headers),
+			Body:       hr.Body,
 		}
-		if s.HTTPRequest.OIDCToken != nil {
-			hr.AuthorizationHeader = &tasks.HttpRequest_OidcToken{
+		if auth, ok := hr.OIDCToken.Get(); ok {
+			req.AuthorizationHeader = &tasks.HttpRequest_OidcToken{
 				OidcToken: &tasks.OidcToken{
-					ServiceAccountEmail: s.HTTPRequest.OIDCToken.ServiceAccountEmail,
-					Audience:            s.HTTPRequest.OIDCToken.Audience,
+					ServiceAccountEmail: auth.ServiceAccountEmail,
+					Audience:            auth.Audience,
 				},
 			}
 		}
 		if view != tasks.Task_FULL {
-			hr.Body = nil
+			req.Body = nil
 		}
-		t.MessageType = &tasks.Task_HttpRequest{HttpRequest: hr}
-	} else if s.AppEngineHTTPRequest != nil {
-		ae := &tasks.AppEngineHttpRequest{
-			HttpMethod:  httpMethodToProto(s.AppEngineHTTPRequest.Method),
-			RelativeUri: s.AppEngineHTTPRequest.RelativeURI,
-			Headers:     copyHeaders(s.AppEngineHTTPRequest.Headers),
-			Body:        s.AppEngineHTTPRequest.Body,
+		t.MessageType = &tasks.Task_HttpRequest{HttpRequest: req}
+	} else if ae, ok := s.AppEngineHTTPRequest.Get(); ok {
+		req := &tasks.AppEngineHttpRequest{
+			HttpMethod:  httpMethodToProto(ae.Method.OrZero()),
+			RelativeUri: ae.RelativeURI.OrZero(),
+			Headers:     copyHeaders(ae.Headers),
+			Body:        ae.Body,
 		}
 		if view != tasks.Task_FULL {
-			ae.Body = nil
+			req.Body = nil
 		}
-		if r := s.AppEngineHTTPRequest.AppEngineRouting; r != nil {
-			ae.AppEngineRouting = &tasks.AppEngineRouting{
+		if r, ok := ae.AppEngineRouting.Get(); ok {
+			req.AppEngineRouting = &tasks.AppEngineRouting{
 				Service:  r.Service,
 				Version:  r.Version,
 				Instance: r.Instance,
 				Host:     r.Host,
 			}
 		}
-		t.MessageType = &tasks.Task_AppEngineHttpRequest{AppEngineHttpRequest: ae}
+		t.MessageType = &tasks.Task_AppEngineHttpRequest{AppEngineHttpRequest: req}
 	}
 	return t
 }
 
-func attemptFromProto(a *tasks.Attempt) *engine.Attempt {
-	out := &engine.Attempt{}
+func attemptFromProto(a *tasks.Attempt) engine.Attempt {
+	out := engine.Attempt{}
 	if a.GetScheduleTime() != nil {
-		out.ScheduleTime = a.GetScheduleTime().AsTime()
+		out.ScheduleTime = maybe.Some(a.GetScheduleTime().AsTime())
 	}
 	if a.GetDispatchTime() != nil {
-		out.DispatchTime = a.GetDispatchTime().AsTime()
+		out.DispatchTime = maybe.Some(a.GetDispatchTime().AsTime())
 	}
 	if a.GetResponseTime() != nil {
-		out.ResponseTime = a.GetResponseTime().AsTime()
+		out.ResponseTime = maybe.Some(a.GetResponseTime().AsTime())
 	}
 	if rs := a.GetResponseStatus(); rs != nil {
-		out.ResponseStatus = &engine.AttemptStatus{Code: rs.GetCode(), Message: rs.GetMessage()}
+		out.ResponseStatus = maybe.Some(engine.AttemptStatus{Code: rs.GetCode(), Message: rs.GetMessage()})
 	}
 	return out
 }
 
-func attemptToProto(a *engine.Attempt) *tasks.Attempt {
+func attemptToProto(a engine.Attempt) *tasks.Attempt {
 	out := &tasks.Attempt{}
-	if !a.ScheduleTime.IsZero() {
-		out.ScheduleTime = timestampToProto(a.ScheduleTime)
+	if st, ok := a.ScheduleTime.Get(); ok {
+		out.ScheduleTime = timestampToProto(st)
 	}
-	if !a.DispatchTime.IsZero() {
-		out.DispatchTime = timestampToProto(a.DispatchTime)
+	if dt, ok := a.DispatchTime.Get(); ok {
+		out.DispatchTime = timestampToProto(dt)
 	}
-	if !a.ResponseTime.IsZero() {
-		out.ResponseTime = timestampToProto(a.ResponseTime)
+	if rt, ok := a.ResponseTime.Get(); ok {
+		out.ResponseTime = timestampToProto(rt)
 	}
-	if a.ResponseStatus != nil {
+	if rs, ok := a.ResponseStatus.Get(); ok {
 		out.ResponseStatus = &rpcstatus.Status{
-			Code:    a.ResponseStatus.Code,
-			Message: a.ResponseStatus.Message,
+			Code:    rs.Code,
+			Message: rs.Message,
 		}
 	}
 	return out


### PR DESCRIPTION
## Summary

Replaces implicit nil-pointer and zero-value sentinels on the engine's `TaskState`/`QueueState` types with `maybe.Maybe[T]`, so a field that may be genuinely absent is visible in the type rather than inferred from a zero value.

The convention: a field that may be genuinely absent (an unset input still awaiting a server default, or state a task has not reached yet) is a `maybe.Maybe[T]`. Only always-present values stay plain: counters, resource names, the queue-run enum, an attempt's status code/message, and a present token's mandatory service-account email (whose optionality is already carried by `Maybe[OIDCToken]`).

## Commits

- **Make optionality explicit in TaskState/QueueState via maybe.Maybe** — wraps timestamps, deadlines, attempt fields, rate-limit/retry knobs, method/OIDC/routing sub-messages; `setInitial*State` defaults via `Or`/`defaultIfAbsent` instead of `== 0`/`IsZero`.
- **Wrap every optional request field in maybe.Maybe** — extends the convention to the last zero-value-sentinel holdouts: `HTTPRequest` URL/Headers/Body, `AppEngineHTTPRequest` Headers/Body, `OIDCToken.Audience`, and `AppEngineRouting` Service/Version/Instance/Host.

## Proto edge

The `From`/`To`Proto mapping funnels through `Some`/`Get`, `OfNonZero` (comparable scalars), and a `someIfNonNil` helper for maps/slices (which `OfNonZero` can't take). Proto3 cannot distinguish an absent repeated/bytes field from an empty one, so an empty value maps to `None` and round-trips back to an absent proto field.

## Verification

- `go build ./...`, `go vet`, `gofmt`, `golangci-lint` — clean (0 issues)
- Full unit suite — pass
- Conformance suite (`-tags conformance`), incl. the real-SDK-driven `TestEmulatorDispatch` diffing dispatched headers/body/routing against the golden recorded from real Cloud Tasks — all pass