### PR TITLE
Validate queue and task config at Create time

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -185,6 +185,37 @@ No `With*` option for the App Engine emulator host, region ID, or OIDC config,
 all of which the binary exposes as flags. Embedded test users of App Engine
 targets would plausibly want these.
 
+### 13. Task-level numeric ranges are not validated at CreateTask
+
+- [x] Status: done. `validateTaskConfig` (task.go) enforces the per-family
+  `dispatch_deadline` intervals and the 30-day `schedule_time` horizon at
+  `CreateTask`; messages verified against the re-recorded conformance golden
+  (`task-invalid-config` cases). The schedule message interpolates the
+  offending timestamp rendered in US Pacific (mapped in `mapErrForCreateTask`;
+  tzdata embedded in the binary for the Alpine image). Task size limits remain
+  deferred as described below.
+- Location: `internal/engine/engine.go:601` (CreateTask), `internal/engine/task.go`
+
+Follow-up to finding 1, found while fixing it: `CreateTask` validates names and
+target URLs but none of the numeric ranges real Cloud Tasks enforces with
+InvalidArgument:
+
+- `dispatch_deadline` must be in [15s, 30m] for HTTP-target tasks and
+  [15s, 24h15s] for App Engine-target tasks (documented on `tasks.Task`).
+  The emulator accepts anything, including negative values (which become an
+  immediately-failing `http.Client` timeout).
+- `schedule_time` may be at most 30 days in the future (Cloud Tasks quotas).
+  The emulator accepts any timestamp.
+
+Unlike finding 1 these cannot crash the emulator; the gap is fidelity only (a
+task real Cloud Tasks would reject is silently accepted). Task size limits
+(100KB App Engine / 1MB HTTP) are a further gap in the same family, deferred
+for now because the measured "size" needs probing before it can be enforced.
+
+Fix direction: same recipe as finding 1 - validate at `CreateTask` with
+sentinels mapped at the edge, add conformance probe cases, record the golden,
+align messages.
+
 ## Architecture notes (no action required, context for the fixes)
 
 - The task registry is duplicated between `engine.ts` and each `queue.ts`, with

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,0 +1,202 @@
+# Code review findings
+
+Review of the main codebase (engine, server, emulator, oidc, maybe, cmd), 2026-07-14.
+Tests and CI were out of scope. Work through these one by one; check items off as they land.
+
+## Major findings
+
+### 1. Unvalidated queue rate limits can panic and crash the emulator
+
+- [x] Status: done. `validateQueueConfig` (queue.go) rejects out-of-range
+  `RateLimits`/`RetryConfig` at `CreateQueue` with per-violation sentinels
+  mapped to InvalidArgument at the server edge; messages verified against the
+  re-recorded conformance golden (`queue-invalid-config` cases), which also
+  showed real v2 ignores client-supplied `max_burst_size` (output-only), so the
+  proto edge now drops it instead of rejecting it. Token-generator period now
+  computed in float64 (fractional rates work, overflow saturates). Adjacent
+  fixes the validation exposed: `MaxAttempts` -1 is honored as unlimited in
+  `reschedule`, and the backoff doubling term saturates instead of overflowing
+  `time.Duration` for large `MaxDoublings`.
+- Severity: high (process crash from client input)
+- Locations: `internal/engine/queue.go:97,105,173`
+
+Two distinct crash paths, plus a correctness bug, all from client-supplied
+`RateLimits` values that are never validated:
+
+- `newQueue` does `make(chan bool, MaxBurstSize)` and
+  `make(chan struct{}, MaxConcurrentDispatches)` directly from client input.
+  A negative value panics inside the gRPC handler goroutine; grpc-go does not
+  recover panics, so one bad `CreateQueue` kills the process.
+- `runTokenGenerator` computes `time.Second / time.Duration(maxDispatchesPerSecond)`.
+  The float64-to-Duration conversion truncates to integer nanoseconds, so a
+  fractional rate such as `0.5` (legal in real Cloud Tasks) becomes `0` and the
+  division panics in a background goroutine, crashing the process.
+- Non-panicking fractional rates are silently wrong: `1.5` behaves as `1.0`.
+  The period should be computed as `time.Duration(float64(time.Second) / rate)`.
+
+Fix direction: validate `RateLimits`/`RetryConfig` at `CreateQueue` (real Cloud
+Tasks rejects out-of-range values with InvalidArgument) and fix the float
+period arithmetic.
+
+### 2. Task schedule goroutine's send to the queue is not cancellable
+
+- [ ] Status: open
+- Severity: high (goroutine leak, delete does not stick, hard reset hangs)
+- Location: `internal/engine/task.go:270`
+
+Once the schedule timer fires, the goroutine commits to a bare blocking
+`task.queue.fire <- task` with no `select` on `task.cancel`. On a paused queue
+(no dispatcher generation receiving) that goroutine blocks indefinitely.
+Consequences:
+
+- `DeleteTask` on such a task cannot stop it; after `Resume` the deleted task
+  is dispatched anyway.
+- `Delete`/`Stop` of a paused queue leaks the goroutine permanently. This
+  matters for the embedded `emulator` package, where test suites create and
+  close many emulators in one process.
+- Hard-reset `PurgeQueue` blocks on `<-task.done` until the caller's ctx
+  expires, because `markDone` never runs.
+
+Fix direction: make the send cancellable:
+
+```go
+select {
+case task.queue.fire <- task:
+case <-task.cancel:
+    task.markDone()
+}
+```
+
+### 3. RunTask double-dispatches
+
+- [ ] Status: open
+- Severity: high (behavioral: forced task runs twice)
+- Locations: `internal/engine/task.go:242`, `internal/engine/engine.go:683`
+
+`Task.Run` dispatches immediately but never disarms the pending `Schedule`
+goroutine. A task scheduled for the future runs now via `RunTask` and again at
+its original schedule time. On a successful forced run, `markDone` fires, yet
+the armed goroutine still pushes the completed task into `queue.fire` later,
+and the dispatcher attempts it again; `reschedule(retry=true)` can then keep
+retrying it. Real Cloud Tasks resets the schedule so the task runs once.
+
+Fix direction: `Run` must take over the task's single pending schedule (disarm
+the goroutine, e.g. via the cancel channel plus re-arm bookkeeping, or by
+restructuring scheduling so there is one owner of "next fire").
+
+### 4. Retry backoff is anchored to the previous schedule time
+
+- [ ] Status: open
+- Severity: medium (hot retry loop against slow/timing-out targets)
+- Location: `internal/engine/dispatch.go:82`
+
+`updateStateForReschedule` sets the next `ScheduleTime` to the old
+`ScheduleTime` plus backoff. When attempts take long (worst case a
+dispatch-deadline timeout, 600s by default), the computed time is already in
+the past, so `time.After` fires immediately and the target gets hammered with
+effectively zero backoff until doubling catches up. Backoff should be measured
+from the failure time (attempt completion), matching real Cloud Tasks.
+
+### 5. Check-then-insert races in CreateQueue and CreateTask
+
+- [ ] Status: open
+- Severity: medium (duplicate names under concurrency, leaked queue goroutines)
+- Locations: `internal/engine/engine.go:424` vs `:434`, `:625` vs `:652`
+
+Both creates do an existence check and a later insert under separate lock
+acquisitions. Two concurrent creates with the same name both succeed. For
+queues, the loser's token-generator and dispatcher goroutines run forever with
+no `Delete` path (permanent leak). For tasks, both copies get scheduled and
+dispatch.
+
+Fix direction: make the uniqueness check and insert one atomic operation under
+`qsMux`/`tsMux` (a set-if-absent that also consults the tombstone map).
+
+### 6. Queue-name validation is loose
+
+- [ ] Status: open
+- Severity: medium (accepts invalid names real Cloud Tasks rejects)
+- Location: `internal/engine/engine.go:416,420`
+
+- The `CreateQueue` regexes are unanchored, so
+  `junk/projects/a/locations/b/queues/c/junk` passes.
+- There is no check that the queue name falls under `parent` (unlike
+  `CreateTask`, which does the prefix check).
+- The regexes are recompiled on every call; `task.go` correctly uses
+  package-level compiled patterns.
+
+## Minor findings
+
+### 7. AppEngineEmulatorHost parse panic in the request path
+
+- [ ] Status: open
+- Location: `internal/engine/task.go:211`
+
+`setInitialTaskState` panics on an unparseable `AppEngineEmulatorHost`. That is
+an operator flag, but the panic happens at first App Engine task creation
+inside a request handler and crashes the server. Validate the flag at startup
+in `main` (and at `engine.New` for embedded use).
+
+### 8. Inconsistent clock injection
+
+- [ ] Status: open
+- Locations: `internal/engine/task.go:144,146`, `internal/engine/dispatch.go:89,132`, `internal/oidc/token.go:94`
+
+The engine has an injectable `now` for tombstones, but `setInitialTaskState`,
+`updateStateForDispatch`, `updateStateAfterDispatch`, and `oidc.CreateToken`
+call `time.Now` directly, so task/attempt timing is untestable with a fake
+clock.
+
+### 9. Stale Purge comment and dead return value
+
+- [ ] Status: open
+- Location: `internal/engine/queue.go:296`
+
+`Queue.Purge`'s comment says it returns a `WaitGroup` "to allow HardReset to
+wait", but `hardResetQueue` does not use `Purge` and no caller consumes the
+return value.
+
+### 10. Auto-generated task IDs skip uniqueness/tombstone checks
+
+- [ ] Status: open
+- Location: `internal/engine/task.go:139`
+
+Names generated from `rand.Uint64` bypass the exists/recently-deleted checks
+that client-named tasks get; a collision would silently clobber the existing
+task. Astronomically unlikely, but routing both cases through the same
+reservation logic removes the gap for free (and composes with finding 5's
+set-if-absent).
+
+### 11. Unlocked reads of queue.state.RetryConfig from the task path
+
+- [ ] Status: open
+- Location: `internal/engine/dispatch.go:77,169`
+
+Safe today only because `UpdateQueue` is unimplemented and those fields are
+never written after construction. If `UpdateQueue` is ever implemented this
+becomes a data race. Add a comment or a snapshot accessor now.
+
+### 12. Embedded emulator option surface is thinner than the binary's
+
+- [ ] Status: open
+- Location: `emulator/emulator.go`
+
+No `With*` option for the App Engine emulator host, region ID, or OIDC config,
+all of which the binary exposes as flags. Embedded test users of App Engine
+targets would plausibly want these.
+
+## Architecture notes (no action required, context for the fixes)
+
+- The task registry is duplicated between `engine.ts` and each `queue.ts`, with
+  two different tombstone conventions (timestamp map at the engine, nil entries
+  in the queue map). It works, but it is the most intricate part of the design;
+  a single registry keyed by name with an entry state would remove a class of
+  "who owns this entry" reasoning. Findings 2, 3, 5 and 10 all touch this
+  machinery; if fixing them gets awkward, consolidating the registry first may
+  be the cheaper path.
+- Strengths to preserve while fixing: the engine/server layering with sentinel
+  errors mapped at the edge, the `maybe.M` optionality convention, the
+  channel-generation pause/resume design with the queue-level semaphore shared
+  across generations, the `markDone`-before-`done`-close ordering guarantee,
+  and the conformance-golden-driven fidelity (error messages, header rules,
+  the two execution-count families).

--- a/cmd/emulator/main.go
+++ b/cmd/emulator/main.go
@@ -14,6 +14,11 @@ import (
 	"strings"
 	"syscall"
 
+	// Embed the timezone database: the Docker image is bare Alpine with no
+	// tzdata package, and the server renders a schedule time in US Pacific
+	// inside one CreateTask error message (see scheduleTimeErrorZone).
+	_ "time/tzdata"
+
 	tasks "cloud.google.com/go/cloudtasks/apiv2/cloudtaskspb"
 
 	"github.com/aertje/cloud-tasks-emulator/v2/internal/maybe"

--- a/internal/engine/dispatch.go
+++ b/internal/engine/dispatch.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -77,7 +78,14 @@ func updateStateForReschedule(task *Task) {
 	retryConfig := task.queue.state.RetryConfig
 
 	doubling := min(task.state.DispatchCount-1, retryConfig.MaxDoublings.OrZero())
-	backoff := min(retryConfig.MinBackoff.OrZero()*time.Duration(1<<uint32(doubling)), retryConfig.MaxBackoff.OrZero())
+	maxBackoff := retryConfig.MaxBackoff.OrZero()
+	// The exponential term is computed in float64 so a large doubling count
+	// saturates (towards +Inf) and clamps to maxBackoff, instead of overflowing
+	// time.Duration into a negative - i.e. immediate - backoff.
+	backoff := maxBackoff
+	if scaled := float64(retryConfig.MinBackoff.OrZero()) * math.Pow(2, float64(doubling)); scaled < float64(maxBackoff) {
+		backoff = time.Duration(scaled)
+	}
 
 	task.state.ScheduleTime = maybe.Some(task.state.ScheduleTime.OrZero().Add(backoff))
 }
@@ -169,7 +177,8 @@ func (task *Task) reschedule(retry bool, statusCode int) {
 	maxAttempts := task.queue.state.RetryConfig.MaxAttempts.OrZero()
 	task.stateMutex.Unlock()
 
-	if dispatchCount >= maxAttempts {
+	// -1 is the documented "unlimited attempts" marker (see validateQueueConfig).
+	if maxAttempts != -1 && dispatchCount >= maxAttempts {
 		logger.Warn("task exhausted retries", "task", task.state.Name, "attempts", dispatchCount)
 		task.markDone()
 		return

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -421,6 +421,9 @@ func (e *Engine) CreateQueue(ctx context.Context, parent string, qs QueueState) 
 	if !parentMatched {
 		return nil, ErrInvalidParent
 	}
+	if err := validateQueueConfig(qs); err != nil {
+		return nil, err
+	}
 	if _, ok := e.fetchQueue(qs.Name); ok {
 		return nil, ErrQueueAlreadyExists
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -651,6 +651,10 @@ func (e *Engine) CreateTask(ctx context.Context, parent string, ts TaskState) (*
 		}
 	}
 
+	if err := validateTaskConfig(ts, e.now()); err != nil {
+		return nil, TaskState{}, err
+	}
+
 	task, frozen := queue.NewTask(ts)
 	e.setTask(frozen.Name, task)
 	queue.logger.Debug("task received", "task", frozen.Name, "queue", parent)

--- a/internal/engine/engine_internal_test.go
+++ b/internal/engine/engine_internal_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"errors"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -236,6 +237,14 @@ func TestBackoffReschedule(t *testing.T) {
 			dispatchCount: 10, // would be huge, capped at 3s
 			wantBackoff:   3 * time.Second,
 		},
+		{
+			// 100ms << 63 overflows time.Duration; the float64 arithmetic must
+			// saturate and clamp to max backoff rather than go negative.
+			name:          "large doubling count saturates at max backoff",
+			retry:         RetryConfig{MinBackoff: maybe.Some(100 * time.Millisecond), MaxBackoff: maybe.Some(time.Hour), MaxDoublings: maybe.Some[int32](63)},
+			dispatchCount: 64,
+			wantBackoff:   time.Hour,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -279,6 +288,96 @@ func TestQueueLifecycle(t *testing.T) {
 
 	// Deleting a missing queue.
 	assert.ErrorIs(t, e.DeleteQueue(ctx, "projects/p/locations/l/queues/absent"), ErrQueueNotFound)
+}
+
+func TestCreateQueueConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		rate    RateLimits
+		retry   RetryConfig
+		wantErr error // nil means the config must be accepted
+	}{
+		{name: "rate negative", rate: RateLimits{MaxDispatchesPerSecond: maybe.Some(-1.0)}, wantErr: ErrMaxDispatchesPerSecondNegative},
+		{name: "rate zero", rate: RateLimits{MaxDispatchesPerSecond: maybe.Some(0.0)}, wantErr: ErrMaxDispatchesPerSecondNegative},
+		{name: "rate NaN", rate: RateLimits{MaxDispatchesPerSecond: maybe.Some(math.NaN())}, wantErr: ErrMaxDispatchesPerSecondNegative},
+		{name: "rate too high", rate: RateLimits{MaxDispatchesPerSecond: maybe.Some(500.5)}, wantErr: ErrMaxDispatchesPerSecondTooHigh},
+		{name: "rate fractional ok", rate: RateLimits{MaxDispatchesPerSecond: maybe.Some(0.5)}},
+		{name: "rate at limit ok", rate: RateLimits{MaxDispatchesPerSecond: maybe.Some(500.0)}},
+		{name: "burst negative", rate: RateLimits{MaxBurstSize: maybe.Some[int32](-1)}, wantErr: ErrMaxBurstSizeRange},
+		{name: "burst too high", rate: RateLimits{MaxBurstSize: maybe.Some[int32](501)}, wantErr: ErrMaxBurstSizeRange},
+		{name: "burst at limit ok", rate: RateLimits{MaxBurstSize: maybe.Some[int32](500)}},
+		{name: "concurrent negative", rate: RateLimits{MaxConcurrentDispatches: maybe.Some[int32](-1)}, wantErr: ErrMaxConcurrentDispatchesNegative},
+		{name: "concurrent too high", rate: RateLimits{MaxConcurrentDispatches: maybe.Some[int32](5001)}, wantErr: ErrMaxConcurrentDispatchesTooHigh},
+		{name: "concurrent at limit ok", rate: RateLimits{MaxConcurrentDispatches: maybe.Some[int32](5000)}},
+		{name: "max attempts below minus one", retry: RetryConfig{MaxAttempts: maybe.Some[int32](-2)}, wantErr: ErrMaxAttemptsRange},
+		{name: "max attempts unlimited ok", retry: RetryConfig{MaxAttempts: maybe.Some[int32](-1)}},
+		{name: "max doublings negative", retry: RetryConfig{MaxDoublings: maybe.Some[int32](-1)}, wantErr: ErrMaxDoublingsNegative},
+		{name: "max doublings zero ok", retry: RetryConfig{MaxDoublings: maybe.Some[int32](0)}},
+		{name: "min backoff negative", retry: RetryConfig{MinBackoff: maybe.Some(-time.Second)}, wantErr: ErrMinBackoffNegative},
+		{name: "max backoff negative", retry: RetryConfig{MaxBackoff: maybe.Some(-time.Second)}, wantErr: ErrMaxBackoffNegative},
+		{name: "min backoff above max backoff", retry: RetryConfig{MinBackoff: maybe.Some(10 * time.Second), MaxBackoff: maybe.Some(5 * time.Second)}, wantErr: ErrBackoffOrder},
+		{name: "min backoff above default max backoff", retry: RetryConfig{MinBackoff: maybe.Some(2 * time.Hour)}, wantErr: ErrBackoffOrder},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newTestEngine(t, newFakeDispatcher(200))
+			_, err := e.CreateQueue(t.Context(), "projects/p/locations/l", QueueState{
+				Name:        testParent,
+				RateLimits:  tc.rate,
+				RetryConfig: tc.retry,
+			})
+			if tc.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// A fractional dispatch rate is legal in Cloud Tasks. The token generator
+// derives its refill period from the rate by float division; the previous
+// integer arithmetic truncated 0.5 to a zero divisor and panicked in a
+// background goroutine, killing the process.
+func TestFractionalRateQueueDispatches(t *testing.T) {
+	d := newFakeDispatcher(200)
+	e := newTestEngine(t, d)
+
+	_, err := e.CreateQueue(t.Context(), "projects/p/locations/l", QueueState{
+		Name:       testParent,
+		RateLimits: RateLimits{MaxDispatchesPerSecond: maybe.Some(0.5)},
+	})
+	require.NoError(t, err)
+
+	// The initial token-bucket fill covers the first dispatch, so the task runs
+	// immediately despite the slow refill rate.
+	_, _, err = e.CreateTask(t.Context(), testParent, httpTaskState("", time.Time{}))
+	require.NoError(t, err)
+	d.awaitDispatches(t, 1, 2*time.Second)
+}
+
+// MaxAttempts -1 is the documented "unlimited attempts" marker. Before it was
+// honored, dispatchCount >= -1 held on the first attempt and the task was
+// dropped as exhausted; several retries prove the marker works.
+func TestUnlimitedAttemptsKeepRetrying(t *testing.T) {
+	d := newFakeDispatcher(500) // always fails
+	e := newTestEngine(t, d)
+
+	_, err := e.CreateQueue(t.Context(), "projects/p/locations/l", QueueState{
+		Name: testParent,
+		RetryConfig: RetryConfig{
+			MaxAttempts:  maybe.Some[int32](-1),
+			MinBackoff:   maybe.Some(time.Millisecond),
+			MaxBackoff:   maybe.Some(2 * time.Millisecond),
+			MaxDoublings: maybe.Some[int32](1),
+		},
+	})
+	require.NoError(t, err)
+
+	_, _, err = e.CreateTask(t.Context(), testParent, httpTaskState(testParent+"/tasks/undying", time.Time{}))
+	require.NoError(t, err)
+
+	d.awaitDispatches(t, 5, 2*time.Second)
 }
 
 func TestCreateTaskValidation(t *testing.T) {

--- a/internal/engine/engine_internal_test.go
+++ b/internal/engine/engine_internal_test.go
@@ -154,6 +154,20 @@ func httpTaskState(name string, schedule time.Time) TaskState {
 	}
 }
 
+// appEngineTaskState builds a valid App Engine-target task state, optionally
+// with a fixed name and schedule time (zero schedule leaves it unset).
+func appEngineTaskState(name string, schedule time.Time) TaskState {
+	scheduleTime := maybe.None[time.Time]()
+	if !schedule.IsZero() {
+		scheduleTime = maybe.Some(schedule)
+	}
+	return TaskState{
+		Name:                 name,
+		ScheduleTime:         scheduleTime,
+		AppEngineHTTPRequest: maybe.Some(AppEngineHTTPRequest{}),
+	}
+}
+
 func TestParseTaskName(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -405,6 +419,49 @@ func TestCreateTaskValidation(t *testing.T) {
 	}
 }
 
+func TestCreateTaskConfigValidation(t *testing.T) {
+	// Future schedule times keep the accepted tasks from dispatching mid-test.
+	future := time.Now().Add(time.Hour)
+	farFuture := time.Now().Add(31 * 24 * time.Hour)
+	okFuture := time.Now().Add(29 * 24 * time.Hour)
+
+	withDeadline := func(s TaskState, d time.Duration) TaskState {
+		s.DispatchDeadline = maybe.Some(d)
+		return s
+	}
+
+	tests := []struct {
+		name    string
+		state   TaskState
+		wantErr error // nil means the task must be accepted
+	}{
+		{name: "http deadline too short", state: withDeadline(httpTaskState("", future), 14*time.Second), wantErr: ErrDispatchDeadlineHTTPRange},
+		{name: "http deadline negative", state: withDeadline(httpTaskState("", future), -time.Second), wantErr: ErrDispatchDeadlineHTTPRange},
+		{name: "http deadline too long", state: withDeadline(httpTaskState("", future), 31*time.Minute), wantErr: ErrDispatchDeadlineHTTPRange},
+		{name: "http deadline at lower limit ok", state: withDeadline(httpTaskState("", future), 15*time.Second)},
+		{name: "http deadline at upper limit ok", state: withDeadline(httpTaskState("", future), 30*time.Minute)},
+		{name: "app engine deadline too short", state: withDeadline(appEngineTaskState("", future), 14*time.Second), wantErr: ErrDispatchDeadlineAppEngineRange},
+		{name: "app engine deadline too long", state: withDeadline(appEngineTaskState("", future), 25*time.Hour), wantErr: ErrDispatchDeadlineAppEngineRange},
+		// One hour is legal for an App Engine target but out of range for an
+		// HTTP target, pinning the per-family split.
+		{name: "app engine deadline one hour ok", state: withDeadline(appEngineTaskState("", future), time.Hour)},
+		{name: "schedule too far in future", state: httpTaskState("", farFuture), wantErr: ErrScheduleTimeTooFarInFuture},
+		{name: "schedule within horizon ok", state: httpTaskState("", okFuture)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newTestEngine(t, newFakeDispatcher(200))
+			createRunningQueue(t, e)
+			_, _, err := e.CreateTask(t.Context(), testParent, tc.state)
+			if tc.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestCreateTaskRejectsDuplicateName(t *testing.T) {
 	e := newTestEngine(t, newFakeDispatcher(200))
 	createRunningQueue(t, e)
@@ -630,7 +687,11 @@ func (e *Engine) countTaskTombstones() int {
 
 func TestTombstoneExpiry(t *testing.T) {
 	const ttl = time.Minute
-	base := time.Unix(1_700_000_000, 0)
+	// The fake clock is anchored to the real current time (only relative
+	// advances matter here) so the real-clock-relative schedule times used
+	// below stay inside CreateTask's 30-day horizon check, which reads the
+	// engine's injected clock.
+	base := time.Now()
 
 	tests := []struct {
 		name string
@@ -711,7 +772,8 @@ func TestTombstoneExpiry(t *testing.T) {
 
 func TestSweepRemovesExpiredTombstones(t *testing.T) {
 	const ttl = time.Minute
-	clock := newFakeClock(time.Unix(1_700_000_000, 0))
+	// Anchored to the real current time for the same reason as TestTombstoneExpiry.
+	clock := newFakeClock(time.Now())
 	e := newClockedTestEngine(t, clock, ttl)
 
 	// Tombstone one task and one queue.

--- a/internal/engine/errors.go
+++ b/internal/engine/errors.go
@@ -32,6 +32,14 @@ var (
 	ErrInvalidTaskID       = errors.New("invalid task id")
 	ErrTaskQueueMismatch   = errors.New("task name does not belong to queue")
 
+	// Task-configuration violations, reported by CreateTask (see
+	// validateTaskConfig). Real Cloud Tasks rejects these with InvalidArgument.
+	// The dispatch-deadline interval depends on the target family, so each
+	// family gets its own sentinel.
+	ErrDispatchDeadlineHTTPRange      = errors.New("http dispatch deadline out of range")
+	ErrDispatchDeadlineAppEngineRange = errors.New("app engine dispatch deadline out of range")
+	ErrScheduleTimeTooFarInFuture     = errors.New("schedule time too far in the future")
+
 	// ErrHTTPRequestURLRequired and ErrHTTPRequestURLScheme report the two
 	// create-time URL validations Cloud Tasks performs on an HTTP-target task:
 	// the URL must be present and must start with http:// or https://. Cloud

--- a/internal/engine/errors.go
+++ b/internal/engine/errors.go
@@ -9,6 +9,22 @@ var (
 	ErrInvalidQueueName     = errors.New("invalid queue name")
 	ErrInvalidParent        = errors.New("invalid parent")
 
+	// Queue-configuration violations, reported by CreateQueue (see
+	// validateQueueConfig). Real Cloud Tasks rejects these with InvalidArgument
+	// and distinguishes a negative value from one above the allowed maximum
+	// (see the queue-invalid-config cases in conformance/golden/errors.json),
+	// so each direction gets its own sentinel.
+	ErrMaxDispatchesPerSecondNegative  = errors.New("max dispatches per second negative")
+	ErrMaxDispatchesPerSecondTooHigh   = errors.New("max dispatches per second too high")
+	ErrMaxBurstSizeRange               = errors.New("max burst size out of range")
+	ErrMaxConcurrentDispatchesNegative = errors.New("max concurrent dispatches negative")
+	ErrMaxConcurrentDispatchesTooHigh  = errors.New("max concurrent dispatches too high")
+	ErrMaxAttemptsRange                = errors.New("max attempts out of range")
+	ErrMaxDoublingsNegative            = errors.New("max doublings negative")
+	ErrMinBackoffNegative              = errors.New("min backoff negative")
+	ErrMaxBackoffNegative              = errors.New("max backoff negative")
+	ErrBackoffOrder                    = errors.New("min backoff greater than max backoff")
+
 	ErrTaskNotFound        = errors.New("task not found")
 	ErrTaskRecentlyDeleted = errors.New("task recently deleted")
 	ErrTaskAlreadyExists   = errors.New("task already exists")

--- a/internal/engine/queue.go
+++ b/internal/engine/queue.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"log/slog"
+	"math"
 	"sync"
 	"time"
 
@@ -146,15 +147,94 @@ func (queue *Queue) retireTask(task *Task) {
 	}
 }
 
-func setInitialQueueState(s *QueueState) {
-	s.RateLimits.MaxDispatchesPerSecond = s.RateLimits.MaxDispatchesPerSecond.Or(500.0)
-	s.RateLimits.MaxBurstSize = s.RateLimits.MaxBurstSize.Or(100)
-	s.RateLimits.MaxConcurrentDispatches = s.RateLimits.MaxConcurrentDispatches.Or(1000)
+// Server defaults applied to absent queue-configuration fields, matching the
+// documented Cloud Tasks defaults.
+const (
+	defaultMaxDispatchesPerSecond        = 500.0
+	defaultMaxBurstSize            int32 = 100
+	defaultMaxConcurrentDispatches int32 = 1000
+	defaultMaxAttempts             int32 = 100
+	defaultMaxDoublings            int32 = 16
+	defaultMinBackoff                    = 100 * time.Millisecond
+	defaultMaxBackoff                    = 3600 * time.Second
+)
 
-	s.RetryConfig.MaxAttempts = s.RetryConfig.MaxAttempts.Or(100)
-	s.RetryConfig.MaxDoublings = s.RetryConfig.MaxDoublings.Or(16)
-	s.RetryConfig.MinBackoff = s.RetryConfig.MinBackoff.Or(100 * time.Millisecond)
-	s.RetryConfig.MaxBackoff = s.RetryConfig.MaxBackoff.Or(3600 * time.Second)
+// Upper bounds on client-supplied queue configuration, from the documented
+// Cloud Tasks limits (see the field docs on tasks.RateLimits). The burst-size
+// bound is queue.yaml's bucket_size limit: the v2 API treats max_burst_size as
+// output-only, but the emulator accepts it as input, so it bounds it too.
+const (
+	maxAllowedDispatchesPerSecond        = 500.0
+	maxAllowedBurstSize            int32 = 500
+	maxAllowedConcurrentDispatches int32 = 5000
+)
+
+// validateQueueConfig rejects out-of-range RateLimits/RetryConfig values on a
+// queue-creation input, as real Cloud Tasks does (verified against the
+// queue-invalid-config cases in conformance/golden/errors.json). Beyond
+// fidelity, this guards the emulator's own internals: newQueue sizes channels
+// from MaxBurstSize and MaxConcurrentDispatches (a negative capacity panics
+// make), and runTokenGenerator derives its refill period from
+// MaxDispatchesPerSecond (a non-positive rate breaks that arithmetic). The
+// MaxBurstSize check is engine-only: on the wire the field is output-only and
+// dropped at the proto edge, mirroring real v2, so it can only be set by
+// embedded callers. Absent fields are valid and get server defaults
+// (setInitialQueueState); the backoff-order check therefore compares the
+// effective values, defaults included.
+func validateQueueConfig(s QueueState) error {
+	if v, ok := s.RateLimits.MaxDispatchesPerSecond.Get(); ok {
+		if v > maxAllowedDispatchesPerSecond {
+			return ErrMaxDispatchesPerSecondTooHigh
+		}
+		// Written !(v > 0) rather than v < 0 so zero (unrepresentable on the
+		// wire, where proto3 zero means unset, but possible for embedded
+		// callers) and NaN (which fails every ordered comparison) are rejected
+		// too - the token generator cannot run with either.
+		if !(v > 0) {
+			return ErrMaxDispatchesPerSecondNegative
+		}
+	}
+	if v, ok := s.RateLimits.MaxBurstSize.Get(); ok && (v < 1 || v > maxAllowedBurstSize) {
+		return ErrMaxBurstSizeRange
+	}
+	if v, ok := s.RateLimits.MaxConcurrentDispatches.Get(); ok {
+		if v > maxAllowedConcurrentDispatches {
+			return ErrMaxConcurrentDispatchesTooHigh
+		}
+		// Zero (embedded callers only, see above) would mean a semaphore no
+		// dispatch could ever acquire a slot on.
+		if v < 1 {
+			return ErrMaxConcurrentDispatchesNegative
+		}
+	}
+	// -1 is the documented "unlimited attempts" marker.
+	if v, ok := s.RetryConfig.MaxAttempts.Get(); ok && v < -1 {
+		return ErrMaxAttemptsRange
+	}
+	if v, ok := s.RetryConfig.MaxDoublings.Get(); ok && v < 0 {
+		return ErrMaxDoublingsNegative
+	}
+	if v, ok := s.RetryConfig.MinBackoff.Get(); ok && v < 0 {
+		return ErrMinBackoffNegative
+	}
+	if v, ok := s.RetryConfig.MaxBackoff.Get(); ok && v < 0 {
+		return ErrMaxBackoffNegative
+	}
+	if s.RetryConfig.MinBackoff.OrElse(defaultMinBackoff) > s.RetryConfig.MaxBackoff.OrElse(defaultMaxBackoff) {
+		return ErrBackoffOrder
+	}
+	return nil
+}
+
+func setInitialQueueState(s *QueueState) {
+	s.RateLimits.MaxDispatchesPerSecond = s.RateLimits.MaxDispatchesPerSecond.Or(defaultMaxDispatchesPerSecond)
+	s.RateLimits.MaxBurstSize = s.RateLimits.MaxBurstSize.Or(defaultMaxBurstSize)
+	s.RateLimits.MaxConcurrentDispatches = s.RateLimits.MaxConcurrentDispatches.Or(defaultMaxConcurrentDispatches)
+
+	s.RetryConfig.MaxAttempts = s.RetryConfig.MaxAttempts.Or(defaultMaxAttempts)
+	s.RetryConfig.MaxDoublings = s.RetryConfig.MaxDoublings.Or(defaultMaxDoublings)
+	s.RetryConfig.MinBackoff = s.RetryConfig.MinBackoff.Or(defaultMinBackoff)
+	s.RetryConfig.MaxBackoff = s.RetryConfig.MaxBackoff.Or(defaultMaxBackoff)
 
 	s.State = QueueRunStateRunning
 }
@@ -170,7 +250,14 @@ func (queue *Queue) startDispatch(stop <-chan struct{}) {
 }
 
 func (queue *Queue) runTokenGenerator(stop <-chan struct{}) {
-	period := time.Second / time.Duration(queue.maxDispatchesPerSecond)
+	// The refill period is computed in float64: integer Duration division would
+	// truncate a fractional rate (e.g. 0.5/s, legal in Cloud Tasks) to a zero
+	// divisor. A rate so small the period overflows time.Duration saturates at
+	// the maximum instead.
+	period := time.Duration(math.MaxInt64)
+	if p := float64(time.Second) / queue.maxDispatchesPerSecond; p < math.MaxInt64 {
+		period = time.Duration(p)
+	}
 	// Use Timer with Reset() in place of time.Ticker as the latter was causing high CPU usage in Docker
 	t := time.NewTimer(period)
 

--- a/internal/engine/task.go
+++ b/internal/engine/task.go
@@ -127,6 +127,39 @@ func hasHeaderFold(headers map[string]string, name string) bool {
 	return false
 }
 
+// Documented Cloud Tasks bounds on task configuration: the dispatch-deadline
+// intervals from the tasks.Task field docs (per target family), the schedule
+// horizon from the Cloud Tasks quotas page.
+const (
+	minDispatchDeadline          = 15 * time.Second
+	maxHTTPDispatchDeadline      = 30 * time.Minute
+	maxAppEngineDispatchDeadline = 24*time.Hour + 15*time.Second
+	maxScheduleAhead             = 30 * 24 * time.Hour
+)
+
+// validateTaskConfig rejects out-of-range numeric values on a task-creation
+// input, as real Cloud Tasks does. Unlike queue configuration these cannot
+// crash the emulator (a bad deadline just makes an http.Client timeout), so
+// this is purely fidelity: a task real Cloud Tasks would reject must not be
+// accepted. Absent fields are valid and get server defaults
+// (setInitialTaskState). now anchors the schedule-horizon check and comes from
+// the engine's injectable clock.
+func validateTaskConfig(s TaskState, now time.Time) error {
+	if d, ok := s.DispatchDeadline.Get(); ok {
+		if s.AppEngineHTTPRequest.IsPresent() {
+			if d < minDispatchDeadline || d > maxAppEngineDispatchDeadline {
+				return ErrDispatchDeadlineAppEngineRange
+			}
+		} else if d < minDispatchDeadline || d > maxHTTPDispatchDeadline {
+			return ErrDispatchDeadlineHTTPRange
+		}
+	}
+	if st, ok := s.ScheduleTime.Get(); ok && st.After(now.Add(maxScheduleAhead)) {
+		return ErrScheduleTimeTooFarInFuture
+	}
+	return nil
+}
+
 // setInitialTaskState fills in the server-assigned defaults on a freshly created
 // task. appEngineEmulatorHost is the base URL App Engine target tasks route to instead
 // of the production appspot.com host; an empty value keeps the appspot.com

--- a/internal/engine/worker_pool_internal_test.go
+++ b/internal/engine/worker_pool_internal_test.go
@@ -69,9 +69,10 @@ func TestDispatchConcurrencyIsBounded(t *testing.T) {
 
 	_, err := e.CreateQueue(t.Context(), "projects/p/locations/l", QueueState{
 		Name: testParent,
-		// A generous rate limit so the token bucket, a separate axis, does not
-		// throttle the backlog and mask the concurrency bound under test.
-		RateLimits: RateLimits{MaxConcurrentDispatches: maybe.Some[int32](maxConcurrent), MaxBurstSize: maybe.Some[int32](100), MaxDispatchesPerSecond: maybe.Some[float64](1000)},
+		// A generous rate limit (the allowed maximum) so the token bucket, a
+		// separate axis, does not throttle the backlog and mask the concurrency
+		// bound under test.
+		RateLimits: RateLimits{MaxConcurrentDispatches: maybe.Some[int32](maxConcurrent), MaxBurstSize: maybe.Some[int32](100), MaxDispatchesPerSecond: maybe.Some[float64](500)},
 	})
 	require.NoError(t, err)
 

--- a/internal/server/protohelpers.go
+++ b/internal/server/protohelpers.go
@@ -405,6 +405,14 @@ func mapErr(err error) error {
 		return status.Errorf(codes.AlreadyExists, "Requested entity already exists")
 	case engine.ErrInvalidTaskName:
 		return status.Errorf(codes.InvalidArgument, `Task name must be formatted: "projects/<PROJECT_ID>/locations/<LOCATION_ID>/queues/<QUEUE_ID>/tasks/<TASK_ID>"`)
+	// The dispatch-deadline messages are verified against the
+	// task-invalid-config cases in conformance/golden/errors.json. The
+	// schedule-horizon sentinel is mapped in mapErrForCreateTask: its message
+	// interpolates the offending schedule time from the request.
+	case engine.ErrDispatchDeadlineHTTPRange:
+		return status.Errorf(codes.InvalidArgument, "Task.dispatchDeadline must be between [15s, 30m].")
+	case engine.ErrDispatchDeadlineAppEngineRange:
+		return status.Errorf(codes.InvalidArgument, "Task.dispatchDeadline must be between [15s, 24h15s].")
 	case engine.ErrHTTPRequestURLRequired:
 		return status.Errorf(codes.InvalidArgument, "HttpRequest.url is required.")
 	case engine.ErrHTTPRequestURLScheme:
@@ -464,6 +472,15 @@ func mapErrForCreateTask(err error, in *tasks.CreateTaskRequest) error {
 			in.GetParent(),
 			queueNameFromTaskName(in.GetTask().GetName()),
 		)
+	case engine.ErrScheduleTimeTooFarInFuture:
+		// The message names the offending schedule time, rendered in US
+		// Pacific time (the golden was recorded as -08:00 for a December
+		// instant; a DST-affected summer instant is extrapolated to render as
+		// -07:00 via the location, not a fixed offset).
+		return status.Errorf(codes.InvalidArgument,
+			"The Task.scheduleTime, %s, is too far in the future. Schedule time must be no more than 720h in the future.",
+			in.GetTask().GetScheduleTime().AsTime().In(scheduleTimeErrorZone).Format(time.RFC3339),
+		)
 	case engine.ErrInvalidTaskID:
 		// The message names the offending task ID; real Cloud Tasks also
 		// attaches a Help detail pointing at the task-name field definition.
@@ -478,6 +495,17 @@ func mapErrForCreateTask(err error, in *tasks.CreateTaskRequest) error {
 	}
 	return mapErr(err)
 }
+
+// scheduleTimeErrorZone is the zone real Cloud Tasks renders the offending
+// schedule time in inside the too-far-in-the-future message (US Pacific).
+// Falls back to a fixed -08:00 offset on hosts without tzdata, matching the
+// recorded winter golden but losing DST fidelity.
+var scheduleTimeErrorZone = func() *time.Location {
+	if loc, err := time.LoadLocation("America/Los_Angeles"); err == nil {
+		return loc
+	}
+	return time.FixedZone("-08:00", -8*60*60)
+}()
 
 // queueNameFromTaskName strips the "/tasks/<id>" suffix off a task resource
 // name, yielding the queue it belongs to. Returns the input unchanged if it has

--- a/internal/server/protohelpers.go
+++ b/internal/server/protohelpers.go
@@ -29,9 +29,13 @@ func queueFromProto(q *tasks.Queue) engine.QueueState {
 		State: queueRunStateFromProto(q.GetState()),
 	}
 	if rl := q.GetRateLimits(); rl != nil {
+		// max_burst_size is deliberately not mapped: it is output-only in the
+		// v2 API and real Cloud Tasks ignores any client-supplied value (even a
+		// negative one - see conformance case queue/create/burst-negative,
+		// which records OK). The engine applies its default; embedded engine
+		// callers can still set the field directly.
 		s.RateLimits = engine.RateLimits{
 			MaxDispatchesPerSecond:  maybe.OfNonZero(rl.GetMaxDispatchesPerSecond()),
-			MaxBurstSize:            maybe.OfNonZero(rl.GetMaxBurstSize()),
 			MaxConcurrentDispatches: maybe.OfNonZero(rl.GetMaxConcurrentDispatches()),
 		}
 	}
@@ -364,6 +368,34 @@ func mapErr(err error) error {
 		)
 	case engine.ErrInvalidParent:
 		return status.Errorf(codes.InvalidArgument, "Invalid resource field value in the request.")
+	// The queue-configuration messages below are verified against the
+	// queue-invalid-config cases in conformance/golden/errors.json, except
+	// where noted.
+	case engine.ErrMaxDispatchesPerSecondNegative:
+		return status.Errorf(codes.InvalidArgument, "RateLimits.maxDispatchesPerSecond cannot be negative.")
+	case engine.ErrMaxDispatchesPerSecondTooHigh:
+		return status.Errorf(codes.InvalidArgument, "RateLimits.maxDispatchesPerSecond must be less than or equal to 500.")
+	case engine.ErrMaxBurstSizeRange:
+		// Unreachable from the wire (queueFromProto drops the output-only
+		// field, matching real v2, which never rejects it); mapped defensively
+		// so a future edge change cannot surface it as Internal.
+		return status.Errorf(codes.InvalidArgument, "RateLimits.maxBurstSize must be between 1 and 500.")
+	case engine.ErrMaxConcurrentDispatchesNegative:
+		return status.Errorf(codes.InvalidArgument, "RateLimits.maxConcurrentDispatches cannot be negative.")
+	case engine.ErrMaxConcurrentDispatchesTooHigh:
+		return status.Errorf(codes.InvalidArgument, "RateLimits.maxConcurrentDispatches must be less than or equal to 5000.")
+	case engine.ErrMaxAttemptsRange:
+		return status.Errorf(codes.InvalidArgument, "RetryConfig.maxAttempts must be greater or equal to -1.")
+	case engine.ErrMaxDoublingsNegative:
+		return status.Errorf(codes.InvalidArgument, "RetryConfig.maxDoublings cannot be negative.")
+	case engine.ErrMinBackoffNegative:
+		return status.Errorf(codes.InvalidArgument, "RetryConfig.minBackoff cannot be negative.")
+	case engine.ErrMaxBackoffNegative:
+		// Extrapolated from the recorded minBackoff/maxDoublings pattern; no
+		// golden case captures a negative max_backoff yet.
+		return status.Errorf(codes.InvalidArgument, "RetryConfig.maxBackoff cannot be negative.")
+	case engine.ErrBackoffOrder:
+		return status.Errorf(codes.InvalidArgument, "RetryConfig.minBackoff must be less than or equal to RetryConfig.maxBackoff.")
 	case engine.ErrTaskNotFound:
 		// GetTask/DeleteTask/RunTask all report a missing task with this generic message.
 		return status.Errorf(codes.NotFound, "Requested entity was not found.")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -289,6 +289,26 @@ func TestCreateTaskRejectsNameForOtherQueue(t *testing.T) {
 	assertIsGrpcError(t, "^The queue name from request", grpcCodes.InvalidArgument, err)
 }
 
+// Out-of-range task configuration must come back as InvalidArgument; the
+// engine-level table test covers the full matrix, this pins the gRPC mapping.
+func TestCreateTaskRejectsOutOfRangeDispatchDeadline(t *testing.T) {
+	t.Parallel()
+	_, client := setUp(t, ServerOptions{})
+
+	createdQueue := createTestQueue(t, client)
+
+	_, err := client.CreateTask(context.Background(), &taskspb.CreateTaskRequest{
+		Parent: createdQueue.GetName(),
+		Task: &taskspb.Task{
+			DispatchDeadline: durationpb.New(31 * time.Minute),
+			MessageType: &taskspb.Task_HttpRequest{
+				HttpRequest: &taskspb.HttpRequest{Url: "http://www.google.com"},
+			},
+		},
+	})
+	assertIsGrpcError(t, `^Task\.dispatchDeadline must be between \[15s, 30m\]\.$`, grpcCodes.InvalidArgument, err)
+}
+
 func TestCreateTaskRejectsMissingURL(t *testing.T) {
 	t.Parallel()
 	_, client := setUp(t, ServerOptions{})

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -81,6 +81,61 @@ func TestCloudTasksCreateQueue(t *testing.T) {
 	assert.Equal(t, taskspb.Queue_RUNNING, resp.State)
 }
 
+// Out-of-range queue configuration must come back as InvalidArgument. The
+// negative-capacity case used to panic inside the handler goroutine (channel
+// sizes were taken straight from client input), killing the whole process.
+func TestCreateQueueRejectsInvalidConfig(t *testing.T) {
+	t.Parallel()
+	_, client := setUp(t, ServerOptions{})
+
+	queue := newQueue(formattedParent, t.Name())
+	queue.RateLimits = &taskspb.RateLimits{MaxConcurrentDispatches: -1}
+
+	_, err := client.CreateQueue(context.Background(), &taskspb.CreateQueueRequest{
+		Parent: formattedParent,
+		Queue:  queue,
+	})
+	assertIsGrpcError(t, `^RateLimits\.maxConcurrentDispatches cannot be negative\.$`, grpcCodes.InvalidArgument, err)
+}
+
+// max_burst_size is output-only in the v2 API: real Cloud Tasks ignores any
+// client-supplied value rather than rejecting it (conformance case
+// queue/create/burst-negative records OK), so even a negative one - which
+// would have panicked the channel allocation - must be dropped and the
+// server-picked default returned.
+func TestCreateQueueIgnoresClientBurstSize(t *testing.T) {
+	t.Parallel()
+	_, client := setUp(t, ServerOptions{})
+
+	queue := newQueue(formattedParent, t.Name())
+	queue.RateLimits = &taskspb.RateLimits{MaxBurstSize: -1}
+
+	resp, err := client.CreateQueue(context.Background(), &taskspb.CreateQueueRequest{
+		Parent: formattedParent,
+		Queue:  queue,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(100), resp.GetRateLimits().GetMaxBurstSize())
+}
+
+// A fractional dispatch rate is legal in Cloud Tasks; it used to truncate to a
+// zero divisor and panic in the token-generator goroutine after a successful
+// CreateQueue response.
+func TestCreateQueueAcceptsFractionalRate(t *testing.T) {
+	t.Parallel()
+	_, client := setUp(t, ServerOptions{})
+
+	queue := newQueue(formattedParent, t.Name())
+	queue.RateLimits = &taskspb.RateLimits{MaxDispatchesPerSecond: 0.5}
+
+	resp, err := client.CreateQueue(context.Background(), &taskspb.CreateQueueRequest{
+		Parent: formattedParent,
+		Queue:  queue,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0.5, resp.GetRateLimits().GetMaxDispatchesPerSecond())
+}
+
 func TestCreateTask(t *testing.T) {
 	t.Parallel()
 	_, client := setUp(t, ServerOptions{})

--- a/test/conformance/cases.go
+++ b/test/conformance/cases.go
@@ -7,6 +7,7 @@ import (
 	cloudtasks "cloud.google.com/go/cloudtasks/apiv2"
 	taskspb "cloud.google.com/go/cloudtasks/apiv2/cloudtaskspb"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Client is the official Cloud Tasks client; the same type drives both the real
@@ -37,6 +38,32 @@ func httpTask(name string) *taskspb.Task {
 		MessageType: &taskspb.Task_HttpRequest{
 			HttpRequest: &taskspb.HttpRequest{Url: "https://example.com/"},
 		},
+	}
+}
+
+// appEngineTask returns a minimal valid App Engine-target task body.
+func appEngineTask(name string) *taskspb.Task {
+	return &taskspb.Task{
+		Name: name,
+		MessageType: &taskspb.Task_AppEngineHttpRequest{
+			AppEngineHttpRequest: &taskspb.AppEngineHttpRequest{},
+		},
+	}
+}
+
+// createTaskMod returns an Invoke that creates the task built by mk for the
+// variant's task path after applying mod, for probing how Cloud Tasks
+// validates task configuration at create time. The offending values are
+// static inputs, stable across variants.
+func createTaskMod(mk func(string) *taskspb.Task, mod func(*taskspb.Task)) func(ctx context.Context, c *Client, p Params) error {
+	return func(ctx context.Context, c *Client, p Params) error {
+		task := mk(p.TaskPath())
+		mod(task)
+		_, err := c.CreateTask(ctx, &taskspb.CreateTaskRequest{
+			Parent: p.QueuePath(),
+			Task:   task,
+		})
+		return err
 	}
 }
 
@@ -321,6 +348,59 @@ func Cases() []Case {
 			Name: "task/create/invalid-url-bad-escape", RPC: "CreateTask", Category: "task-invalid-url",
 			Setup:    createQueue,
 			Invoke:   createTaskURL("http://example.com/%zz"),
+			Teardown: deleteQueue,
+		},
+		// --- CreateTask configuration validation ---
+		// Probes how Cloud Tasks rejects out-of-range task values at create
+		// time (code and message): dispatch_deadline must be in [15s, 30m] for
+		// HTTP targets and [15s, 24h15s] for App Engine targets, and
+		// schedule_time may be at most 30 days in the future. The one-hour
+		// App Engine deadline case is expected to record OK - it is legal
+		// there and illegal for HTTP, pinning the per-family split. Its
+		// schedule time is pushed out an hour so the created task never
+		// actually dispatches during the run.
+		{
+			Name: "task/create/deadline-too-short", RPC: "CreateTask", Category: "task-invalid-config",
+			Setup: createQueue,
+			Invoke: createTaskMod(httpTask, func(t *taskspb.Task) {
+				t.DispatchDeadline = durationpb.New(5 * time.Second)
+			}),
+			Teardown: deleteQueue,
+		},
+		{
+			Name: "task/create/deadline-too-long", RPC: "CreateTask", Category: "task-invalid-config",
+			Setup: createQueue,
+			Invoke: createTaskMod(httpTask, func(t *taskspb.Task) {
+				t.DispatchDeadline = durationpb.New(31 * time.Minute)
+			}),
+			Teardown: deleteQueue,
+		},
+		{
+			Name: "task/create/appengine-deadline-too-long", RPC: "CreateTask", Category: "task-invalid-config",
+			Setup: createQueue,
+			Invoke: createTaskMod(appEngineTask, func(t *taskspb.Task) {
+				t.DispatchDeadline = durationpb.New(25 * time.Hour)
+			}),
+			Teardown: deleteQueue,
+		},
+		{
+			Name: "task/create/appengine-deadline-one-hour", RPC: "CreateTask", Category: "task-invalid-config",
+			Setup: createQueue,
+			Invoke: createTaskMod(appEngineTask, func(t *taskspb.Task) {
+				t.DispatchDeadline = durationpb.New(time.Hour)
+				t.ScheduleTime = timestamppb.New(time.Now().Add(time.Hour))
+			}),
+			Teardown: deleteQueue,
+		},
+		{
+			// The timestamp is a fixed far-future instant rather than a
+			// now-relative one so every variant sends the same value and any
+			// interpolation of it into the message stays stable.
+			Name: "task/create/schedule-too-far", RPC: "CreateTask", Category: "task-invalid-config",
+			Setup: createQueue,
+			Invoke: createTaskMod(httpTask, func(t *taskspb.Task) {
+				t.ScheduleTime = timestamppb.New(time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC))
+			}),
 			Teardown: deleteQueue,
 		},
 		{

--- a/test/conformance/cases.go
+++ b/test/conformance/cases.go
@@ -2,9 +2,11 @@ package conformance
 
 import (
 	"context"
+	"time"
 
 	cloudtasks "cloud.google.com/go/cloudtasks/apiv2"
 	taskspb "cloud.google.com/go/cloudtasks/apiv2/cloudtaskspb"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // Client is the official Cloud Tasks client; the same type drives both the real
@@ -72,6 +74,20 @@ func createTaskURL(url string) func(ctx context.Context, c *Client, p Params) er
 					HttpRequest: &taskspb.HttpRequest{Url: url},
 				},
 			},
+		})
+		return err
+	}
+}
+
+// createQueueConfig returns an Invoke that creates a queue carrying the
+// supplied rate limits / retry config, for probing how Cloud Tasks validates
+// queue configuration at create time. The offending values are static inputs,
+// stable across variants.
+func createQueueConfig(rl *taskspb.RateLimits, rc *taskspb.RetryConfig) func(ctx context.Context, c *Client, p Params) error {
+	return func(ctx context.Context, c *Client, p Params) error {
+		_, err := c.CreateQueue(ctx, &taskspb.CreateQueueRequest{
+			Parent: p.Parent(),
+			Queue:  &taskspb.Queue{Name: p.QueuePath(), RateLimits: rl, RetryConfig: rc},
 		})
 		return err
 	}
@@ -165,6 +181,62 @@ func Cases() []Case {
 				})
 				return err
 			},
+		},
+
+		// --- CreateQueue configuration validation ---
+		// Probes how Cloud Tasks rejects out-of-range RateLimits/RetryConfig
+		// values at create time (code and message), pinning down the validation
+		// the emulator enforces before sizing queue internals from these
+		// fields. Teardown deletes best-effort because one case succeeds: real
+		// v2 treats max_burst_size as output-only and ignores the client value,
+		// so burst-negative creates the queue and records OK.
+		{
+			Name: "queue/create/rate-negative", RPC: "CreateQueue", Category: "queue-invalid-config",
+			Invoke:   createQueueConfig(&taskspb.RateLimits{MaxDispatchesPerSecond: -1}, nil),
+			Teardown: deleteQueue,
+		},
+		{
+			Name: "queue/create/rate-too-high", RPC: "CreateQueue", Category: "queue-invalid-config",
+			Invoke:   createQueueConfig(&taskspb.RateLimits{MaxDispatchesPerSecond: 501}, nil),
+			Teardown: deleteQueue,
+		},
+		{
+			Name: "queue/create/burst-negative", RPC: "CreateQueue", Category: "queue-invalid-config",
+			Invoke:   createQueueConfig(&taskspb.RateLimits{MaxBurstSize: -1}, nil),
+			Teardown: deleteQueue,
+		},
+		{
+			Name: "queue/create/concurrent-negative", RPC: "CreateQueue", Category: "queue-invalid-config",
+			Invoke:   createQueueConfig(&taskspb.RateLimits{MaxConcurrentDispatches: -1}, nil),
+			Teardown: deleteQueue,
+		},
+		{
+			Name: "queue/create/concurrent-too-high", RPC: "CreateQueue", Category: "queue-invalid-config",
+			Invoke:   createQueueConfig(&taskspb.RateLimits{MaxConcurrentDispatches: 5001}, nil),
+			Teardown: deleteQueue,
+		},
+		{
+			Name: "queue/create/max-attempts-below-minus-one", RPC: "CreateQueue", Category: "queue-invalid-config",
+			Invoke:   createQueueConfig(nil, &taskspb.RetryConfig{MaxAttempts: -2}),
+			Teardown: deleteQueue,
+		},
+		{
+			Name: "queue/create/max-doublings-negative", RPC: "CreateQueue", Category: "queue-invalid-config",
+			Invoke:   createQueueConfig(nil, &taskspb.RetryConfig{MaxDoublings: -1}),
+			Teardown: deleteQueue,
+		},
+		{
+			Name: "queue/create/min-backoff-negative", RPC: "CreateQueue", Category: "queue-invalid-config",
+			Invoke:   createQueueConfig(nil, &taskspb.RetryConfig{MinBackoff: durationpb.New(-time.Second)}),
+			Teardown: deleteQueue,
+		},
+		{
+			Name: "queue/create/backoff-order", RPC: "CreateQueue", Category: "queue-invalid-config",
+			Invoke: createQueueConfig(nil, &taskspb.RetryConfig{
+				MinBackoff: durationpb.New(10 * time.Second),
+				MaxBackoff: durationpb.New(5 * time.Second),
+			}),
+			Teardown: deleteQueue,
 		},
 
 		// --- Task lifecycle, inside a real queue ---

--- a/test/conformance/golden/errors.json
+++ b/test/conformance/golden/errors.json
@@ -180,6 +180,38 @@
     "stable": true
   },
   {
+    "name": "task/create/appengine-deadline-one-hour",
+    "rpc": "CreateTask",
+    "category": "task-invalid-config",
+    "code": "OK",
+    "template": "",
+    "stable": true
+  },
+  {
+    "name": "task/create/appengine-deadline-too-long",
+    "rpc": "CreateTask",
+    "category": "task-invalid-config",
+    "code": "InvalidArgument",
+    "template": "Task.dispatchDeadline must be between [15s, 24h15s].",
+    "stable": true
+  },
+  {
+    "name": "task/create/deadline-too-long",
+    "rpc": "CreateTask",
+    "category": "task-invalid-config",
+    "code": "InvalidArgument",
+    "template": "Task.dispatchDeadline must be between [15s, 30m].",
+    "stable": true
+  },
+  {
+    "name": "task/create/deadline-too-short",
+    "rpc": "CreateTask",
+    "category": "task-invalid-config",
+    "code": "InvalidArgument",
+    "template": "Task.dispatchDeadline must be between [15s, 30m].",
+    "stable": true
+  },
+  {
     "name": "task/create/invalid-name",
     "rpc": "CreateTask",
     "category": "task-invalid-name",
@@ -247,6 +279,14 @@
     "category": "queue-recently-deleted",
     "code": "NotFound",
     "template": "Queue does not exist. If you just created the queue, wait at least a minute for the queue to initialize.",
+    "stable": true
+  },
+  {
+    "name": "task/create/schedule-too-far",
+    "rpc": "CreateTask",
+    "category": "task-invalid-config",
+    "code": "InvalidArgument",
+    "template": "The Task.scheduleTime, 2099-12-31T16:00:00-08:00, is too far in the future. Schedule time must be no more than 720h in the future.",
     "stable": true
   },
   {

--- a/test/conformance/golden/errors.json
+++ b/test/conformance/golden/errors.json
@@ -48,7 +48,7 @@
     "details": [
       {
         "type": "*errdetails.Help",
-        "template": "links:{description:\"Definition of queue name\"  url:\"https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues#Queue.FIELDS.name\"}"
+        "template": "links:{description:\"Definition of queue name\" url:\"https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues#Queue.FIELDS.name\"}"
       }
     ],
     "stable": true
@@ -62,15 +62,15 @@
     "details": [
       {
         "type": "*errdetails.ErrorInfo",
-        "template": "reason:\"CONSUMER_INVALID\"  domain:\"googleapis.com\"  metadata:{key:\"consumer\"  value:\"projects/not-a-valid-parent\"}  metadata:{key:\"containerInfo\"  value:\"not-a-valid-parent\"}  metadata:{key:\"service\"  value:\"cloudtasks.googleapis.com\"}"
+        "template": "reason:\"CONSUMER_INVALID\" domain:\"googleapis.com\" metadata:{key:\"consumer\" value:\"projects/not-a-valid-parent\"} metadata:{key:\"containerInfo\" value:\"not-a-valid-parent\"} metadata:{key:\"service\" value:\"cloudtasks.googleapis.com\"}"
       },
       {
         "type": "*errdetails.LocalizedMessage",
-        "template": "locale:\"en-US\"  message:\"Permission denied on resource project not-a-valid-parent.\""
+        "template": "locale:\"en-US\" message:\"Permission denied on resource project not-a-valid-parent.\""
       },
       {
         "type": "*errdetails.Help",
-        "template": "links:{description:\"Google developers console\"  url:\"https://console.developers.google.com\"}"
+        "template": "links:{description:\"Google developers console\" url:\"https://console.developers.google.com\"}"
       }
     ],
     "stable": true
@@ -220,7 +220,7 @@
     "details": [
       {
         "type": "*errdetails.Help",
-        "template": "links:{description:\"Definition of task ID\"  url:\"https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues.tasks#Task.FIELDS.name\"}"
+        "template": "links:{description:\"Definition of task ID\" url:\"https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues.tasks#Task.FIELDS.name\"}"
       }
     ],
     "stable": true

--- a/test/conformance/golden/errors.json
+++ b/test/conformance/golden/errors.json
@@ -8,6 +8,38 @@
     "stable": true
   },
   {
+    "name": "queue/create/backoff-order",
+    "rpc": "CreateQueue",
+    "category": "queue-invalid-config",
+    "code": "InvalidArgument",
+    "template": "RetryConfig.minBackoff must be less than or equal to RetryConfig.maxBackoff.",
+    "stable": true
+  },
+  {
+    "name": "queue/create/burst-negative",
+    "rpc": "CreateQueue",
+    "category": "queue-invalid-config",
+    "code": "OK",
+    "template": "",
+    "stable": true
+  },
+  {
+    "name": "queue/create/concurrent-negative",
+    "rpc": "CreateQueue",
+    "category": "queue-invalid-config",
+    "code": "InvalidArgument",
+    "template": "RateLimits.maxConcurrentDispatches cannot be negative.",
+    "stable": true
+  },
+  {
+    "name": "queue/create/concurrent-too-high",
+    "rpc": "CreateQueue",
+    "category": "queue-invalid-config",
+    "code": "InvalidArgument",
+    "template": "RateLimits.maxConcurrentDispatches must be less than or equal to 5000.",
+    "stable": true
+  },
+  {
     "name": "queue/create/invalid-name",
     "rpc": "CreateQueue",
     "category": "queue-invalid-name",
@@ -16,7 +48,7 @@
     "details": [
       {
         "type": "*errdetails.Help",
-        "template": "links:{description:\"Definition of queue name\" url:\"https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues#Queue.FIELDS.name\"}"
+        "template": "links:{description:\"Definition of queue name\"  url:\"https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues#Queue.FIELDS.name\"}"
       }
     ],
     "stable": true
@@ -30,17 +62,57 @@
     "details": [
       {
         "type": "*errdetails.ErrorInfo",
-        "template": "reason:\"CONSUMER_INVALID\" domain:\"googleapis.com\" metadata:{key:\"consumer\" value:\"projects/not-a-valid-parent\"} metadata:{key:\"containerInfo\" value:\"not-a-valid-parent\"} metadata:{key:\"service\" value:\"cloudtasks.googleapis.com\"}"
+        "template": "reason:\"CONSUMER_INVALID\"  domain:\"googleapis.com\"  metadata:{key:\"consumer\"  value:\"projects/not-a-valid-parent\"}  metadata:{key:\"containerInfo\"  value:\"not-a-valid-parent\"}  metadata:{key:\"service\"  value:\"cloudtasks.googleapis.com\"}"
       },
       {
         "type": "*errdetails.LocalizedMessage",
-        "template": "locale:\"en-US\" message:\"Permission denied on resource project not-a-valid-parent.\""
+        "template": "locale:\"en-US\"  message:\"Permission denied on resource project not-a-valid-parent.\""
       },
       {
         "type": "*errdetails.Help",
-        "template": "links:{description:\"Google developers console\" url:\"https://console.developers.google.com\"}"
+        "template": "links:{description:\"Google developers console\"  url:\"https://console.developers.google.com\"}"
       }
     ],
+    "stable": true
+  },
+  {
+    "name": "queue/create/max-attempts-below-minus-one",
+    "rpc": "CreateQueue",
+    "category": "queue-invalid-config",
+    "code": "InvalidArgument",
+    "template": "RetryConfig.maxAttempts must be greater or equal to -1.",
+    "stable": true
+  },
+  {
+    "name": "queue/create/max-doublings-negative",
+    "rpc": "CreateQueue",
+    "category": "queue-invalid-config",
+    "code": "InvalidArgument",
+    "template": "RetryConfig.maxDoublings cannot be negative.",
+    "stable": true
+  },
+  {
+    "name": "queue/create/min-backoff-negative",
+    "rpc": "CreateQueue",
+    "category": "queue-invalid-config",
+    "code": "InvalidArgument",
+    "template": "RetryConfig.minBackoff cannot be negative.",
+    "stable": true
+  },
+  {
+    "name": "queue/create/rate-negative",
+    "rpc": "CreateQueue",
+    "category": "queue-invalid-config",
+    "code": "InvalidArgument",
+    "template": "RateLimits.maxDispatchesPerSecond cannot be negative.",
+    "stable": true
+  },
+  {
+    "name": "queue/create/rate-too-high",
+    "rpc": "CreateQueue",
+    "category": "queue-invalid-config",
+    "code": "InvalidArgument",
+    "template": "RateLimits.maxDispatchesPerSecond must be less than or equal to 500.",
     "stable": true
   },
   {
@@ -116,7 +188,7 @@
     "details": [
       {
         "type": "*errdetails.Help",
-        "template": "links:{description:\"Definition of task ID\" url:\"https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues.tasks#Task.FIELDS.name\"}"
+        "template": "links:{description:\"Definition of task ID\"  url:\"https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues.tasks#Task.FIELDS.name\"}"
       }
     ],
     "stable": true

--- a/test/conformance/record.go
+++ b/test/conformance/record.go
@@ -120,7 +120,10 @@ func invoke(ctx context.Context, c *Client, cs Case, p Params) Result {
 		if !ok {
 			continue
 		}
-		text := prototext.MarshalOptions{}.Format(msg)
+		// prototext's field separator is deliberately unstable (one or two
+		// spaces at random), so canonicalise here to keep the recorded golden
+		// from churning cosmetically between runs. See canonicalSpace.
+		text := canonicalSpace(prototext.MarshalOptions{}.Format(msg))
 		r.Details = append(r.Details, DetailRecord{
 			Type:     fmt.Sprintf("%T", d),
 			Template: Normalize(text, p),


### PR DESCRIPTION
Merges `create-config-validation` into a fresh `fable-review` branch off `v2`.

## Summary

Adds validation of queue and task configuration at Create time, so invalid client input is rejected with `InvalidArgument` at the server edge instead of causing bad state or process crashes.

- **CreateQueue**: validates `RateLimits` and `RetryConfig`, rejecting out-of-range values with per-violation sentinel errors mapped to `InvalidArgument`. Token-generator period is now computed in float64 (fractional rates work, overflow saturates). `max_burst_size` is dropped at the proto edge to match real v2 behaviour (output-only). Adjacent fixes: `MaxAttempts` -1 honored as unlimited in `reschedule`; backoff doubling saturates instead of overflowing `time.Duration` for large `MaxDoublings`.
- **CreateTask**: validates the task dispatch deadline and schedule horizon.
- Conformance cases and golden errors re-recorded to match.

## Notes

- Includes `FINDINGS.md`, the code-review tracking document that accompanied this work.

## Test plan

- [ ] Unit tests (`internal/engine`, `internal/server`) pass
- [ ] Conformance suite passes against re-recorded golden