### PR TITLE
Fix RunTask double-dispatching a future-scheduled task

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -5,23 +5,6 @@ Tests and CI were out of scope. Work through these one by one; check items off a
 
 ## Major findings
 
-### 1. RunTask double-dispatches
-
-- [ ] Status: open
-- Severity: high (behavioral: forced task runs twice)
-- Locations: `internal/engine/task.go:242`, `internal/engine/engine.go:683`
-
-`Task.Run` dispatches immediately but never disarms the pending `Schedule`
-goroutine. A task scheduled for the future runs now via `RunTask` and again at
-its original schedule time. On a successful forced run, `markDone` fires, yet
-the armed goroutine still pushes the completed task into `queue.fire` later,
-and the dispatcher attempts it again; `reschedule(retry=true)` can then keep
-retrying it. Real Cloud Tasks resets the schedule so the task runs once.
-
-Fix direction: `Run` must take over the task's single pending schedule (disarm
-the goroutine, e.g. via the cancel channel plus re-arm bookkeeping, or by
-restructuring scheduling so there is one owner of "next fire").
-
 ### 2. Retry backoff is anchored to the previous schedule time
 
 - [ ] Status: open

--- a/internal/engine/engine_internal_test.go
+++ b/internal/engine/engine_internal_test.go
@@ -477,6 +477,32 @@ func TestCreateTaskRejectsDuplicateName(t *testing.T) {
 	assert.ErrorIs(t, err, ErrTaskAlreadyExists)
 }
 
+// TestRunTaskDispatchesOnce verifies that forcing a future-scheduled task to run
+// now dispatches it exactly once: Run must take over the pending schedule so the
+// task does not also fire at its original schedule time (a double dispatch).
+func TestRunTaskDispatchesOnce(t *testing.T) {
+	d := newFakeDispatcher(200)
+	e := newTestEngine(t, d)
+	createRunningQueue(t, e)
+	ctx := t.Context()
+
+	// Schedule the task a second out, then force it to run immediately.
+	name := testParent + "/tasks/forced"
+	_, _, err := e.CreateTask(ctx, testParent, httpTaskState(name, time.Now().Add(time.Second)))
+	require.NoError(t, err)
+
+	_, _, err = e.RunTask(ctx, name)
+	require.NoError(t, err)
+
+	// Run dispatches now, well before the original schedule time...
+	d.awaitDispatches(t, 1, 500*time.Millisecond)
+
+	// ...and the superseded schedule must not fire a second dispatch once its
+	// original time (1s) passes.
+	require.Never(t, func() bool { return d.count() > 1 }, 1500*time.Millisecond, 10*time.Millisecond)
+	assert.Equal(t, 1, d.count())
+}
+
 func TestDeleteTaskTombstonesName(t *testing.T) {
 	e := newTestEngine(t, newFakeDispatcher(200))
 	createRunningQueue(t, e)

--- a/internal/engine/task.go
+++ b/internal/engine/task.go
@@ -64,6 +64,16 @@ type Task struct {
 
 	cancel chan bool
 
+	// armInterrupt identifies the task's single pending fire, guarded by
+	// stateMutex. Schedule installs a fresh channel when it arms the next fire;
+	// whoever dispatches the task (the scheduled goroutine or a forced Run)
+	// consumes the arming by clearing this field, so the task dispatches at most
+	// once per arming. Run additionally closes the consumed channel to wake a
+	// scheduled goroutine still waiting on its timer. A nil value means there is
+	// no unclaimed pending fire (the task is dispatching, terminal, or between
+	// armings).
+	armInterrupt chan struct{}
+
 	onDone func(*Task)
 
 	// done is closed exactly once, after onDone has finished running, when the
@@ -273,11 +283,54 @@ func (task *Task) Attempt() {
 // Run runs the task outside of the normal queueing mechanism.
 // This method is called directly by request.
 func (task *Task) Run() TaskState {
+	// Take over the task's pending fire so it does not also dispatch at its
+	// original schedule time (a double dispatch). If the scheduled fire has
+	// already been consumed - the task is dispatching through the normal path
+	// right now - Run does not dispatch a second time and just returns a current
+	// snapshot, matching Cloud Tasks running the task once.
+	interrupt, ok := task.disarm()
+	if !ok {
+		return task.State()
+	}
+	// Wake the scheduled goroutine so it stands down promptly rather than
+	// lingering until its (now-superseded) schedule time.
+	close(interrupt)
+
 	frozen := updateStateForDispatch(task)
 
 	go task.doDispatch(false, frozen)
 
 	return frozen
+}
+
+// disarm consumes the task's current pending fire, returning its interrupt
+// channel, or (nil, false) if there is no unclaimed pending fire. It is how Run
+// takes a scheduled task over: the caller owns the resulting dispatch and closes
+// the returned channel to release the scheduled goroutine.
+func (task *Task) disarm() (chan struct{}, bool) {
+	task.stateMutex.Lock()
+	defer task.stateMutex.Unlock()
+	if task.armInterrupt == nil {
+		return nil, false
+	}
+	interrupt := task.armInterrupt
+	task.armInterrupt = nil
+	return interrupt, true
+}
+
+// claimScheduledFire lets a scheduled goroutine consume the pending fire it was
+// armed with. It succeeds only while that arming is still current: a later
+// arming (a retry or dispatcher re-arm) or a Run takeover clears or replaces
+// armInterrupt, so a stale goroutine stands down instead of dispatching a
+// superseded fire.
+func (task *Task) claimScheduledFire(interrupt chan struct{}) bool {
+	task.stateMutex.Lock()
+	defer task.stateMutex.Unlock()
+	if task.armInterrupt != interrupt {
+		return false
+	}
+	task.armInterrupt = nil
+	return true
 }
 
 // Delete cancels the task if it is queued for execution.
@@ -293,6 +346,10 @@ func (task *Task) Delete() {
 func (task *Task) Schedule() {
 	task.stateMutex.Lock()
 	scheduleTime := task.state.ScheduleTime.OrZero()
+	// Arm a fresh pending fire. The interrupt channel identifies this arming so a
+	// concurrent Run can take the task over (see disarm/claimScheduledFire).
+	interrupt := make(chan struct{})
+	task.armInterrupt = interrupt
 	task.stateMutex.Unlock()
 
 	fromNow := time.Until(scheduleTime)
@@ -300,6 +357,12 @@ func (task *Task) Schedule() {
 	go func() {
 		select {
 		case <-time.After(fromNow):
+			// Consume this arming before handing the task to the dispatcher. A
+			// forced Run may have taken it over in the meantime, in which case the
+			// task is already dispatching and this fire must stand down.
+			if !task.claimScheduledFire(interrupt) {
+				return
+			}
 			// The queue may be paused (nothing draining fire) between the timer
 			// firing and this send; keep listening on cancel so Delete still
 			// takes effect instead of leaking this goroutine or dispatching a
@@ -311,6 +374,10 @@ func (task *Task) Schedule() {
 			}
 		case <-task.cancel:
 			task.markDone()
+		case <-interrupt:
+			// A forced Run took the task over before the timer fired; it
+			// dispatches the task directly, so this arming stands down.
+			return
 		}
 	}()
 }


### PR DESCRIPTION
## Summary

Addresses finding #1 from `FINDINGS.md`: `RunTask` double-dispatches a future-scheduled task.

`Task.Run` dispatched immediately but never disarmed the pending `Schedule` goroutine, so a future-scheduled task ran **twice**: once now via `RunTask` and again at its original schedule time (which could then spin into a retry loop). Real Cloud Tasks resets the schedule so the task runs once.

## Fix

Give each arming an identity (a per-arming `armInterrupt` channel guarded by `stateMutex`) so there is a single owner of the task's "next fire":

- Both the scheduled goroutine and `Run` must **consume** the current arming before dispatching; consuming clears `armInterrupt`, so exactly one of them dispatches per arming.
- The scheduled goroutine's consume is **identity-checked**, so a stale goroutine (e.g. a far-future timer firing after a takeover + re-arm) can never fire a superseded arming.
- `Run` closes the consumed channel to release a goroutine still waiting on its timer, and declines to dispatch if the scheduled fire already won (returning a current snapshot, matching Cloud Tasks running the task once).

`Delete`'s existing single-shot `cancel` semantics are untouched and compose with the new arming coordination.

## Testing

- New regression test `TestRunTaskDispatchesOnce`: confirmed it **fails on the old code** (two dispatches) and **passes with the fix**.
- Full engine suite passes under `-race`; `go build ./...` and `go test ./...` green; `golangci-lint` reports 0 issues; gopls diagnostics clean.
- Removed the finding from `FINDINGS.md`.